### PR TITLE
Changed ModularWidget name to ModularApp

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,5 +2,5 @@ import 'package:example/app/app_module.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
-void main() => runApp(ModularWidget(module: AppModule()));
+void main() => runApp(ModularApp(module: AppModule()));
 

--- a/lib/flutter_modular.dart
+++ b/lib/flutter_modular.dart
@@ -8,5 +8,5 @@ export 'src/interfaces/route_guard.dart';
 export 'src/inject/inject.dart';
 export 'src/inject/bind.dart';
 export 'src/routers/router.dart';
-export 'src/widgets/module_widget.dart';
+export 'src/widgets/modular_app.dart';
 export 'src/widgets/consumer_widget.dart';

--- a/lib/src/widgets/modular_app.dart
+++ b/lib/src/widgets/modular_app.dart
@@ -2,16 +2,16 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_modular/src/interfaces/main_module.dart';
 
-class ModularWidget extends StatefulWidget {
+class ModularApp extends StatefulWidget {
   final MainModule module;
 
-  const ModularWidget({Key key, this.module}) : super(key: key);
+  const ModularApp({Key key, this.module}) : super(key: key);
 
   @override
-  _ModularWidgetState createState() => _ModularWidgetState();
+  _ModularAppState createState() => _ModularAppState();
 }
 
-class _ModularWidgetState extends State<ModularWidget> {
+class _ModularAppState extends State<ModularApp> {
   @override
   void initState() {
     super.initState();

--- a/test/modular_app_test.dart
+++ b/test/modular_app_test.dart
@@ -8,7 +8,7 @@ main() {
 
   group("Init module widget", () {
     testWidgets('ModularWidget', (WidgetTester tester) async {
-      await tester.pumpWidget(ModularWidget(module: AppModule(),));
+      await tester.pumpWidget(ModularApp(module: AppModule(),));
       final textInject = find.text('testing inject');
       expect(textInject, findsOneWidget);
     });


### PR DESCRIPTION
I just changed the root widget from `ModularWidget` to `ModularApp`

Motivation: As it is the root widget of the app I suggest the name to be `ModularApp`