### PR TITLE
Improve Router class's arguments validation

### DIFF
--- a/lib/src/routers/router.dart
+++ b/lib/src/routers/router.dart
@@ -18,7 +18,16 @@ class Router {
     this.guards,
     this.params,
     this.transition = TransitionType.defaultTransition,
-  });
+  }) {
+    assert(routerName != null);
+
+    if(transition == null)
+      throw ArgumentError('transaction must not be null');
+    if(module == null && child == null)
+       throw ArgumentError('[module] or [child] must be provided');
+    if(module != null && child != null)
+      throw ArgumentError('You should provide only [module] or [child]');
+  }
 
   copyWith({
     Widget Function(BuildContext context, ModularArguments args) child,

--- a/lib/src/routers/router.dart
+++ b/lib/src/routers/router.dart
@@ -38,7 +38,7 @@ class Router {
     TransitionType transition,
   }) {
     return Router(
-      routerName,
+      routerName ?? this.routerName,
       child: child ?? this.child,
       module: module ?? this.module,
       params: params ?? this.params,

--- a/lib/src/routers/router.dart
+++ b/lib/src/routers/router.dart
@@ -29,7 +29,7 @@ class Router {
       throw ArgumentError('You should provide only [module] or [child]');
   }
 
-  copyWith({
+  Router copyWith({
     Widget Function(BuildContext context, ModularArguments args) child,
     String routerName,
     ChildModule module,

--- a/test/modular_test.dart
+++ b/test/modular_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_modular/flutter_modular.dart';
@@ -33,13 +34,13 @@ void main() {
     });
 
     test('search object Router to url', () {
-      var router = Router('/home/list/:id');
+      var router = Router('/home/list/:id', child: (_, __) => SizedBox.shrink());
 
       expect(
           Modular.searchRoute(router, "/home/list/:id", "/home/list/1"), true);
       expect(router.params['id'], 1);
 
-      expect(Modular.searchRoute(Router('/home/list'), "/home/list",  "/home/list/1"), false);
+      expect(Modular.searchRoute(Router('/home/list', child: (_, __) => SizedBox.shrink()), "/home/list",  "/home/list/1"), false);
     });
 
     test('router with params get', () {

--- a/test/routers/router_test.dart
+++ b/test/routers/router_test.dart
@@ -12,6 +12,10 @@ class TestModule extends ChildModule {
 }
 
 void main() {
+  test('throws assertionError routeName is null', () {
+    expect(() => Router(null), throwsAssertionError);
+  });
+
   test('throws ArgumentError if module or child was not provide', () {
     expect(() => Router('/'), throwsArgumentError);
   });

--- a/test/routers/router_test.dart
+++ b/test/routers/router_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestModule extends ChildModule {
+  @override
+  List<Bind> get binds => [];
+
+  @override
+  List<Router> get routers => [];
+
+}
+
+void main() {
+  test('throws ArgumentError if module or child was not provide', () {
+    expect(() => Router('/'), throwsArgumentError);
+  });
+
+  test('throws ArgumentError if both the module and child was provided', () {
+    expect(() {
+      Router('/',
+        module: TestModule(),
+        child: (_, __) => SizedBox.shrink()
+      );
+    }, throwsArgumentError);
+  });
+
+  test('throws ArgumentError if transaction is null', () {
+    expect(() {
+      Router('/',
+          child: (_, __) => SizedBox.shrink(),
+          transition: null,
+      );
+    }, throwsArgumentError);
+  });
+}


### PR DESCRIPTION
I've just improved the `Router` class by:

- [x] Assert that `routeName` is not null
- [x] Asserting that `transaction` argument must not be null
- [x] Asserting that only `module` or `child` must be provided and never both
- [x] Fix routeName null if the function `copyWith `is called without providing the `routeName` property