### PR TITLE
Comandos "print" substituídos por "debugPrint"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ build/
 
 test/.test_coverage.dart
 coverage/
+pubspec.lock
+example/pubspec.lock

--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -9,7 +9,7 @@ import 'transitions/transitions.dart';
 
 _debugPrintModular(String text) {
   if (Modular.debugMode) {
-    print(text);
+    debugPrint(text);
   }
 }
 
@@ -63,9 +63,9 @@ class Modular {
       return p;
     }).toList();
 
-    print('\n*** Modular Routers ***\n');
+    debugPrint('\n*** Modular Routers ***\n');
     paths.forEach(print);
-    print("\n*****\n");
+    debugPrint("\n*****\n");
   }
 
   static _printRoutersModule(ChildModule module, String initialPath,

--- a/lib/src/routers/router.dart
+++ b/lib/src/routers/router.dart
@@ -7,7 +7,7 @@ import 'package:flutter_modular/src/transitions/transitions.dart';
 
 _debugPrintModular(String text) {
   if (Modular.debugMode) {
-    print(text);
+    debugPrint(text);
   }
 }
 

--- a/lib/src/widgets/modular_app.dart
+++ b/lib/src/widgets/modular_app.dart
@@ -25,7 +25,7 @@ class _ModularAppState extends State<ModularApp> {
   void dispose() {
     widget.module.cleanInjects();
     if (Modular.debugMode) {
-      print("-- ${widget.module.runtimeType.toString()} DISPOSED");
+      debugPrint("-- ${widget.module.runtimeType.toString()} DISPOSED");
     }
     super.dispose();
   }

--- a/lib/src/widgets/module_widget.dart
+++ b/lib/src/widgets/module_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 
 _debugPrintModular(String text) {
   if (Modular.debugMode) {
-    print(text);
+    debugPrint(text);
   }
 }
 

--- a/test/app/modules/home/home_bloc.dart
+++ b/test/app/modules/home/home_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 import '../../app_bloc.dart';
@@ -10,6 +11,6 @@ class HomeBloc extends Disposable {
 
   @override
   void dispose() {
-    print('call dispose');
+    debugPrint('call dispose');
   }
 }

--- a/test/app/modules/product/product_bloc.dart
+++ b/test/app/modules/product/product_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class ProductBloc extends Disposable {
@@ -6,7 +7,7 @@ class ProductBloc extends Disposable {
 
   @override
   void dispose() {
-    print('call dispose');
+    debugPrint('call dispose');
   }
 
 }

--- a/test/modular_widget_test.dart
+++ b/test/modular_widget_test.dart
@@ -28,12 +28,12 @@ class OtherWidget extends ModuleWidget {
 
 class OtherWidgetNotLazyError {
   OtherWidgetNotLazyError() {
-    print('Not lazy');
+    debugPrint('Not lazy');
   }
 }
 
 class ObjectTest {
   ObjectTest() {
-    print('lazy');
+    debugPrint('lazy');
   }
 }


### PR DESCRIPTION
O funcionamento do comando `print` não pode ser alterado.

Em contra-partida, podemos utilizar o comando `debugPrint` para manipular o texto do print, seja para adicionar a data antes do conteúdo ou não mostrar nada quando gerar o release para produção.

Veja esses exemplos:

**main_production.dart**
```dart
import 'package:flutter/material.dart';
import 'package:flutter_modular/flutter_modular.dart';
import 'app/app_module.dart';

void main() {
  debugPrint = (String message, {int wrapWidth}) {};
  return runApp(ModularApp(module: AppModule()));
}
```

**main_development.dart**
```dart
import 'package:flutter/foundation.dart';
import 'package:flutter/material.dart';
import 'package:flutter_modular/flutter_modular.dart';

import 'app/app_module.dart';
import 'app/extensions/extensions.dart';

void main() {
  debugPrint = (String message, {int wrapWidth}) {
    final formattedMessage = "[${DateTime.now().toStringFormat()}] $message";
    debugPrintSynchronously(formattedMessage);
  };

  return runApp(ModularApp(module: AppModule()));
}
```