### PR TITLE
Remove uses of RouteSettings.isInitialRoute due to its deprecation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -109,13 +109,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -176,7 +169,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.14"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -362,6 +362,7 @@ class Modular {
 
   static Route<T> generateRoute<T>(RouteSettings settings) {
     String path = settings.name;
+    print("Settings name is ${settings.name}.");
     Router router = selectRoute(path);
     if (router == null) {
       return null;
@@ -369,9 +370,9 @@ class Modular {
     actualRoute = path;
     _args = ModularArguments(router.params, settings.arguments);
 
-    if (settings.isInitialRoute) {
-      router = router.copyWith(transition: TransitionType.noTransition);
-    }
+    // if (settings.isInitialRoute) {
+    //   router = router.copyWith(transition: TransitionType.noTransition);
+    // }
 
     return router.getPageRoute(settings: settings, injectMap: _injectMap);
   }

--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -5,6 +5,7 @@ import 'package:flutter_modular/src/routers/router.dart';
 
 import 'interfaces/child_module.dart';
 import 'interfaces/route_guard.dart';
+import 'routers/router.dart';
 import 'transitions/transitions.dart';
 
 _debugPrintModular(String text) {
@@ -362,7 +363,6 @@ class Modular {
 
   static Route<T> generateRoute<T>(RouteSettings settings) {
     String path = settings.name;
-    print("Settings name is ${settings.name}.");
     Router router = selectRoute(path);
     if (router == null) {
       return null;
@@ -370,9 +370,9 @@ class Modular {
     actualRoute = path;
     _args = ModularArguments(router.params, settings.arguments);
 
-    // if (settings.isInitialRoute) {
-    //   router = router.copyWith(transition: TransitionType.noTransition);
-    // }
+    if (settings.name == initialRoute) {
+      router = router.copyWith(transition: TransitionType.noTransition);
+    }
 
     return router.getPageRoute(settings: settings, injectMap: _injectMap);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -95,13 +95,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -162,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.14"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixed the code according to migration guide here to adapt to breaking change of RouteSettings:
https://flutter.dev/docs/release/breaking-changes/route-navigator-refactoring