### PR TITLE
1. add MaterialPageRoute builder 2. Add guard executors to do sth more

### DIFF
--- a/example/lib/app/app_widget.dart
+++ b/example/lib/app/app_widget.dart
@@ -6,6 +6,7 @@ class AppWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       initialRoute: "/",
+      navigatorKey: Modular.navigatorKey,
       onGenerateRoute: Modular.generateRoute,
     );
   }

--- a/example/lib/app/modules/home/guard/guard.dart
+++ b/example/lib/app/modules/home/guard/guard.dart
@@ -1,8 +1,31 @@
 import 'package:flutter_modular/flutter_modular.dart';
 
+class LoginExecutor extends GuardExecutor {
+
+  final String message;
+  LoginExecutor({this.message});
+
+  @override
+  onGuarded(String path, bool isActive) {
+    if(isActive) {
+      print('logined and pass');
+      return;
+    }
+
+    print('toast: need login => $message');
+
+    // Suppose login.
+    Modular.to.pushNamed('/list/10');
+  }
+}
+
 class MyGuard implements RouteGuard {
   @override
   bool canActivate(String url) {
     return url != '/list/2';
   }
+
+  @override
+  // TODO: implement executors
+  List<GuardExecutor> get executors => [LoginExecutor(message: 'List page')];
 }

--- a/example/lib/app/modules/home/home_module.dart
+++ b/example/lib/app/modules/home/home_module.dart
@@ -1,9 +1,21 @@
 import 'package:example/app/modules/home/pages/list/list_widget.dart';
 import 'package:flutter_modular/flutter_modular.dart';
-
+import 'package:flutter/material.dart';
 import 'guard/guard.dart';
 import 'home_bloc.dart';
 import 'home_widget.dart';
+
+class SlowerPageRoute extends MaterialPageRoute {
+  @override
+  // TODO: implement transitionDuration
+  Duration get transitionDuration => Duration(milliseconds: 1200);
+
+  Map eventP;
+  SlowerPageRoute({
+    @required builder,
+    @required settings,
+  }) : super(builder: builder, settings: settings);
+}
 
 class HomeModule extends ChildModule {
   @override
@@ -19,6 +31,7 @@ class HomeModule extends ChildModule {
         ),
         Router(
           "/list/:id",
+          routeGenerator: (b, s) => SlowerPageRoute(builder: b, settings: s),
           child: (_, args) => ListWidget(
             param: int.parse(args.params['id']),
           ),

--- a/lib/src/interfaces/route_guard.dart
+++ b/lib/src/interfaces/route_guard.dart
@@ -1,4 +1,10 @@
 
+abstract class GuardExecutor {
+  onGuarded(String path, bool isActive);
+}
+
 abstract class RouteGuard {
   bool canActivate(String url);
+
+  List<GuardExecutor> get executors;
 }

--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -248,13 +248,17 @@ class Modular {
 
   static RouteGuard _verifyGuard(List<RouteGuard> guards, String path) {
     RouteGuard guard;
-    try {
-      guard = guards.length == 0
-          ? null
-          : guards.firstWhere((guard) => !guard.canActivate(path),
-              orElse: null);
-    } catch (e) {}
+    var realGuards = guards ?? [];
+    guard = realGuards.length == 0
+        ? null
+        : guards.firstWhere((guard) => !guard.canActivate(path),
+        orElse: () => null);
 
+    realGuards.expand((c) => c.executors).forEach((c) => c.onGuarded(path, guard == null));
+
+    if(guard != null) {
+      throw ModularError("Path guarded : $path");
+    }
     return guard;
   }
 
@@ -313,13 +317,7 @@ class Modular {
         if (searchRoute(route, tempRouteName, path)) {
           var guards = _prepareGuardList(_masterRouteGuards, route.guards);
           _masterRouteGuards = null;
-          RouteGuard guard;
-          try {
-            guard = guards.length == 0
-                ? null
-                : guards.firstWhere((guard) => !guard.canActivate(path),
-                    orElse: null);
-          } catch (e) {}
+          RouteGuard guard = _verifyGuard(guards, path);
           if ((tempRouteName == path || tempRouteName == "$path/") &&
               path != '/') {
             guard = _verifyGuard(guards, path);

--- a/test/app/guard/guard.dart
+++ b/test/app/guard/guard.dart
@@ -5,4 +5,7 @@ class MyGuard implements RouteGuard {
   bool canActivate(String url) {
     return false;
   }
+
+  @override
+  List<GuardExecutor> get executors => [];
 }


### PR DESCRIPTION
First:
`routeGenerator` is added to the Router to customize the Route extends the MaterialPageRoute to ensure the swip-to-back gestures works normally while the animations are changed.

Second: 
Clean up the codes in Modular_base, to ensure _verify_guard method would be called correctly.

1. Throw the guard exceptions while guards are working, instead of the navigation exceptions : [No route founded], which would make us confused.

2. Guard executors feature is added to help us do hack more before navigation.
for example:
[LoginExecutor works with the Guard] can finish the login verification and navigate to the login page, the the Guard with LoginExecutor can be used in all the Routers which need to login.