### PR TITLE
Some Browsers were breaking on route due regex grouping

### DIFF
--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -150,7 +150,7 @@ class Modular {
     List<String> newUrl = [];
     for (var part in url.split('/')) {
       var url =
-          part.contains(":") ? "${part.replaceFirst(':', '(?<')}>.*)" : part;
+      part.contains(":") ? "(.*?)" : part;
       newUrl.add(url);
     }
 
@@ -184,15 +184,24 @@ class Modular {
         caseSensitive: true,
       );
       var r = regExp.firstMatch(path);
-
-      if (r?.groupNames != null) {
+      if (r != null) {
         Map<String, String> params = {};
-        int count = 1;
-        for (var key in r?.groupNames) {
-          routeNamed = routeNamed.replaceFirst(':$key', r?.group(count));
-          params[key] = r?.group(count);
-          count++;
+        int paramPos = 0;
+        var routeParts = routeNamed.split('/');
+        var pathParts = path.split('/');
+
+        print('Match! Processing ${path} as ${routeNamed}');
+
+        for (var routePart in routeParts) {
+          if (routePart.contains(":")) {
+            var paramName = routePart.replaceFirst(':', '');
+            params[paramName] = pathParts[paramPos];
+            routeNamed = routeNamed.replaceFirst(routePart, params[paramName]);
+          }
+          paramPos++;
         }
+
+        print('Result processed ${path} as ${routeNamed}');
 
         if (routeNamed != path) {
           router.params = null;
@@ -209,6 +218,7 @@ class Modular {
 
     return routeNamed == path;
   }
+
 
   static RouteGuard _verifyGuard(List<RouteGuard> guards, String path) {
     RouteGuard guard;

--- a/test/modular_test.dart
+++ b/test/modular_test.dart
@@ -27,11 +27,11 @@ void main() {
     });
 
     test('prepare to regex', () {
-      expect(Modular.prepareToRegex('/home/list/:id'), '/home/list/(?<id>.*)');
+      expect(Modular.prepareToRegex('/home/list/:id'), '/home/list/(.*?)');
       expect(
-          Modular.prepareToRegex('/home/list/:id/'), '/home/list/(?<id>.*)/');
+          Modular.prepareToRegex('/home/list/:id/'), '/home/list/(.*?)/');
       expect(Modular.prepareToRegex('/home/list/:id/item/:num'),
-          '/home/list/(?<id>.*)/item/(?<num>.*)');
+          '/home/list/(.*?)/item/(.*?)');
     });
 
     test('search object Router to url', () {
@@ -41,6 +41,11 @@ void main() {
       expect(
           Modular.searchRoute(router, "/home/list/:id", "/home/list/1"), true);
       expect(router.params['id'], "1");
+
+      expect(
+          Modular.searchRoute(router, "/home/list/:id/item/:num", "/home/list/1/item/2"), true);
+      expect(router.params['id'], "1");
+      expect(router.params['num'], "2");
 
       expect(
           Modular.searchRoute(


### PR DESCRIPTION
This refers to bug reported at: https://github.com/Flutterando/modular/issues/93

Some browsers don't support the group for regex which was breaking them and making impossible to navigate.