### PR TITLE
Renomear ModuleWidget para WidgetModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   - [ModularState](#modularstate)
   - [Consuming a ChangeNotifier Class](#consuming-a-changenotifier-class)
   - [Creating Child Modules](#creating-child-modules)
-  - [ModuleWidget](#modulewidget)
+  - [WidgetModule](#widgetmodule)
   - [RouterOutlet](#routeroutlet)
   - [Lazy Loading](#lazy-loading)
   - [Unit Test](#unit-test)
@@ -503,12 +503,12 @@ class AppModule extends MainModule {
 
 Consider splitting your code into modules such as `LoginModule`, and into it placing routes related to that module. Maintaining and sharing code in another project will be much easier.
 
-### ModuleWidget
+### WidgetModule
 
 The same structure as `ChildModule`. Very useful for modular TabBar visualizations.
 
 ```dart
-class TabModule extends ModuleWidget {
+class TabModule extends WidgetModule {
 
     @override
   List<Bind> get binds => [

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -25,7 +25,7 @@
   - [ModularState](#modularstate)
   - [Consumindo uma Classe ChangeNotifier](#consumindo-uma-classe-changenotifier)
   - [Criando Módulos Filhos](#criando-módulos-filhos)
-  - [ModuleWidget](#modulewidget)
+  - [WidgetModule](#widgetmodule)
   - [RouterOutlet](#routeroutlet)
   - [Lazy Loading](#lazy-loading)
   - [Testes Unitários](#testes-unitários)
@@ -503,12 +503,12 @@ class AppModule extends MainModule {
 
 Pense em dividir seu código em módulos como por exemplo, `LoginModule`, e dentro dele colocar as rotas relacionadas a esse módulo. Ficará muito mais fácil a manutenção e o compartilhamento do código em outro projeto.
 
-### ModuleWidget
+### WidgetModule
 
 A mesma estrutura de um MainModule/ChildModule. Muito útil para usar em uma TabBar com páginas modulares
 
 ```dart
-class TabModule extends ModuleWidget {
+class TabModule extends WidgetModule {
 
     @override
   List<Bind> get binds => [

--- a/lib/src/widgets/module_widget.dart
+++ b/lib/src/widgets/module_widget.dart
@@ -7,7 +7,7 @@ _debugPrintModular(String text) {
   }
 }
 
-abstract class ModuleWidget extends StatelessWidget implements ChildModule {
+abstract class WidgetModule extends StatelessWidget implements ChildModule {
   @override
   List<Bind> get binds;
 
@@ -15,7 +15,7 @@ abstract class ModuleWidget extends StatelessWidget implements ChildModule {
 
   final _FakeModule _fakeModule = _FakeModule();
 
-  ModuleWidget() {
+  WidgetModule() {
     _fakeModule.changeBinds(binds);
   }
 

--- a/test/modular_widget_test.dart
+++ b/test/modular_widget_test.dart
@@ -15,7 +15,7 @@ main() {
   });
 }
 
-class OtherWidget extends ModuleWidget {
+class OtherWidget extends WidgetModule {
   @override
   List<Bind> get binds => [
         Bind((i) => ObjectTest()),


### PR DESCRIPTION
Uma pequena mudança que talvez seja breaking-change mas que melhore a legibilidade do Modular.

Considerando que existem o `MainModule` e o `ChildModule`, acredito que o `ModuleWidget` deveria ser renomeado para `WidgetModule`.

Acho que é uma mudança necessária porque muitas vezes quando fiz uso desse recurso da biblioteca, me encontrei tendo que reescrever o nome do Module duas vezes, já que a primeira coisa que vinha à mente nunca era o nome correto