### PR TITLE
Correção para CustomTransition quando Roteando para modulos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,58 @@ Router("/product",
 
 If you use transition in a module, all routes in that module will inherit this transition animation.
 
+### Custom Transition Animation Route
+
+You can also use a custom transition animation by setting the Router parameters **transistion** and **customTransition** with **TransitionType.custom** and the **CustomTransition**, respectively.
+
+```dart
+Router("/product",
+        module: AdminModule(),
+        transition: TransitionType.custom,
+        customTransition: myCustomTransition),
+
+// ...
+```
+
+And, for example, in a custom transitions file declare your custom transitions.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+CustomTransition get myCustomTransition => CustomTransition(
+    transitionDuration: Duration(milliseconds: 500),
+    transitionBuilder: (context, animation, secondaryAnimation, child){
+      return RotationTransition(turns: animation,
+        child: SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(-1.0, 0.0),
+            end: Offset.zero,
+          ).animate(animation),
+          child: ScaleTransition(
+            scale: Tween<double>(
+              begin: 0.0,
+              end: 1.0,
+            ).animate(CurvedAnimation(
+              parent: animation,
+              curve: Interval(
+                0.00,
+                0.50,
+                curve: Curves.linear,
+              ),
+            ),
+            ),
+            child: child,
+          ),
+        ),
+      )
+      ;
+    },
+  );
+
+
+```
+
 ## Grouping Routes
 
 You can group routes that contains  one (or more) properties in common. Properties **guards**, **transition** and **customTransition** can be used together or just one to group routes in common.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -255,6 +255,59 @@ Router("/product",
 
 Se usar o transition em um módulo, todas as rotas desse módulo herdarão essa animação de transição.
 
+### Animação Customizada para Transição de Rota
+
+Você também pode utilizar uma transição com animação customizada setando os parametros **transistion** e **customTransition** do Router com **TransitionType.custom** e **CustomTransition**, respectivamente.
+
+```dart
+Router("/product",
+        module: AdminModule(),
+        transition: TransitionType.custom,
+        customTransition: myCustomTransition),
+
+// ...
+```
+
+E, por exemplo, num arquivo de transições customizadas, você pode declarar suas transições.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+CustomTransition get myCustomTransition => CustomTransition(
+    transitionDuration: Duration(milliseconds: 500),
+    transitionBuilder: (context, animation, secondaryAnimation, child){
+      return RotationTransition(turns: animation,
+        child: SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(-1.0, 0.0),
+            end: Offset.zero,
+          ).animate(animation),
+          child: ScaleTransition(
+            scale: Tween<double>(
+              begin: 0.0,
+              end: 1.0,
+            ).animate(CurvedAnimation(
+              parent: animation,
+              curve: Interval(
+                0.00,
+                0.50,
+                curve: Curves.linear,
+              ),
+            ),
+            ),
+            child: child,
+          ),
+        ),
+      )
+      ;
+    },
+  );
+
+
+```
+
+
 ## Agrupando rotas
 
 Você pode agrupar rotas que contenham uma (ou mais) propriedades em comum. As propriedades **guards**, **transition** e **customTransition** podem ser usadas em conjunto somente uma para agrupar rotas.

--- a/lib/src/modular_base.dart
+++ b/lib/src/modular_base.dart
@@ -289,6 +289,7 @@ class Modular {
           if (router.transition == TransitionType.defaultTransition) {
             router = router.copyWith(
               transition: route.transition,
+              customTransition: route.customTransition,
             );
           }
           bindModule(route.module, path);

--- a/lib/src/routers/router.dart
+++ b/lib/src/routers/router.dart
@@ -37,6 +37,8 @@ class Router<T> {
     assert(routerName != null);
 
     if (transition == null) throw ArgumentError('transition must not be null');
+    if (transition == TransitionType.custom && customTransition == null)
+      throw ArgumentError('[customTransition] required for transition type [TransitionType.custom]');
     if (module == null && child == null)
       throw ArgumentError('[module] or [child] must be provided');
     if (module != null && child != null)
@@ -131,7 +133,7 @@ class Router<T> {
       {Map<String, ChildModule> injectMap, RouteSettings settings}) {
     final arguments = Modular.args.copy();
 
-    if (this.customTransition != null) {
+    if (this.transition == TransitionType.custom && this.customTransition != null) {
       return PageRouteBuilder(
         pageBuilder: (context, _, __) {
           return _disposableGenerate(context,


### PR DESCRIPTION
O problema ocorre quando faço:

```dart
Router("/product",
   module: ProductModule(), 
   transition: TransitionType.custom,
    customTransition: myCustomTransition
),
```
E, quando faço a chamada ao `Navigator.pushNamed` ou `Modular.to.pushNamed`, ele gera um erro no console do AndroidStudio.

```
════════ Exception caught by gesture ═══════════════════════════════════════════════════════════════
The following NoSuchMethodError was thrown while handling a gesture:
The method 'call' was called on null.
Receiver: null
Tried calling: call()

When the exception was thrown, this was the stack: 
#0      Router.getPageRoute (package:flutter_modular/src/routers/router.dart:162:30)
#1      Modular.generateRoute (package:flutter_modular/src/modular_base.dart:335:19)
#2      _WidgetsAppState._onGenerateRoute (package:flutter/src/widgets/app.dart:762:21)
#3      NavigatorState._routeNamed (package:flutter/src/widgets/navigator.dart:1629:29)
#4      NavigatorState.pushNamed (package:flutter/src/widgets/navigator.dart:1683:20)
...
Handler: "onTap"
Recognizer: TapGestureRecognizer#ffd16
  debugOwner: GestureDetector
  state: possible
  won arena
  finalPosition: Offset(143.1, 330.3)
  finalLocalPosition: Offset(127.1, 28.3)
  button: 1
  sent tap down
════════════════════════════════════════════════════════════════════════════════════════════════════
```
Mas, o mesmo não ocorre quando uso:

```dart
Router("/product",
  child: (_, args) => ProductPage(),
  transition: TransitionType.custom,
  customTransition: myCustomTransition,
),
```
Para corrigir o problema, eu adicionei o `customTranstion: route.customTransition` na lina `292` do `modular_base.dart`. 

As alterações no arquivo `route.dart` são apenas para que se for utilizada a `transition` `TransitionType.custom`, garantir que o parametro `customTansition` também esteja preenchido.

