### PR TITLE
add modular navigator mock example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,11 +876,23 @@ main() {
 ```
 ### Mock the navigation system
 
-We though it would be interesting to provide a native way to mock the navigation system when used with `Modular.to` and `Modular.link`. To do this, you may just implement `IModularNavigator` and pass your implementation to `Modular.navigatorDelegate`.
+We though it would be interesting to provide a native way to mock the navigation system when used with `Modular.to` and `Modular.link`. To do this, you may just implement `IModularNavigator` and pass your implementation to `Modular.navigatorDelegate`. This can be done using Mockito package, according to the following example.
 
 ```dart
-// Modular.to and Modular.link will be called MyNavigatorMock implements!
-Modular.navigatorDelegate = MyNavigatorMock();
+class MyNavigatorMock extends Mock implements IModularNavigator {}
+
+void main() {
+  setUpAll(() {
+    // Modular.to and Modular.link will be called MyNavigatorMock implements!
+    Modular.navigatorDelegate = MyNavigatorMock();
+    initModules([AppModule(), HomeModule()]);
+  });
+  testWidgets('HomePage has scaffold', (tester) async {
+    await tester.pumpWidget(buildTestableWidget(HomePage()));
+    final scaffoldFinder = find.byType(Scaffold);
+    expect(scaffoldFinder, findsOneWidget);
+  });
+}
 ```
 
 ## DebugMode


### PR DESCRIPTION
# Summary

In some widget test cases, router getters are called on null. To avoid this, modular allows to mock its Modular Navigator.  
Documentation had a line about it, but not so clear how to mock it.

## Suggestion

I added an example to be included in documentation. Feel free to adapt or change it to your defaults.