### PR TITLE
Fixed empty query params

### DIFF
--- a/flutter_modular/lib/src/presenters/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_route_information_parser.dart
@@ -151,15 +151,15 @@ class ModularRouteInformationParser extends RouteInformationParser<ModularRoute>
           paramPos++;
         }
         uri = uri.replace(path: routeNamed);
-        return router.copyWith(args: router.args!.copyWith(params: params), uri: uri);
+        return router.copyWith(args: router.args!.copyWith(params: params,uri: uri), uri: uri);
       }
 
       uri = uri.replace(path: routeNamed);
-      return router.copyWith(args: router.args!.copyWith(params: null), uri: uri);
+      return router.copyWith(args: router.args!.copyWith(params: null,uri: uri), uri: uri);
     }
 
     uri = uri.replace(path: routeNamed);
-    return router.copyWith(uri: uri);
+    return router.copyWith(uri: uri,args: router.args!.copyWith(uri: uri));
   }
 
   ModularRoute? _searchWildcard(
@@ -197,17 +197,17 @@ class ModularRouteInformationParser extends RouteInformationParser<ModularRoute>
     var router = _searchInModule(module ?? Modular.initialModule, "", uri);
 
     if (router != null) {
-      return canActivate(path, router);
+      return canActivate(uri.path, router);
     } else {
-      router = _searchWildcard(path, module ?? Modular.initialModule);
+      router = _searchWildcard(uri.path, module ?? Modular.initialModule);
       if (router != null) {
         return router;
       }
     }
-    throw ModularError('Route \'$path\' not found');
+    throw ModularError('Route \'${uri.path}\' not found');
   }
 
-  
+
 
   Future<ModularRoute> canActivate(String path, ModularRoute router) async {
     if (router.guards?.isNotEmpty == true) {

--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -70,7 +70,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
 
   String resolverPath(String routeName, String path) {
     final uri = Uri.parse(path);
-    return uri.resolve(routeName).path;
+    return '${uri.resolve(routeName).toString()}';
   }
 
   @override

--- a/flutter_modular/test/src/presenters/navigation/modular_route_information_parse_test.dart
+++ b/flutter_modular/test/src/presenters/navigation/modular_route_information_parse_test.dart
@@ -33,8 +33,63 @@ main() {
       expect(route.path, '/list/2');
     });
 
+    test('should retrieve route /list?id=1234&type=DYN', () async {
+      final route = await parse.selectRoute('/list?id=1234&type=DYN', ModuleMock());
+      expect(route, isNotNull);
+      expect(route.child!(context, null), isA<ListView>());
+      expect(route.path, '/list?id=1234&type=DYN');
+      expect(route.uri?.path, '/list');
+      expect(route.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.fragment, '');
+      expect(route.args?.uri?.path, '/list');
+      expect(route.args?.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.args?.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.args?.fragment, '');
+    });
+
+    test('should retrieve route /list?id=1234&type=DYN#abcd', () async {
+      final route = await parse.selectRoute('/list?id=1234&type=DYN#abcd', ModuleMock());
+      expect(route, isNotNull);
+      expect(route.child!(context, null), isA<ListView>());
+      expect(route.path, '/list?id=1234&type=DYN#abcd');
+      expect(route.uri?.path, '/list');
+      expect(route.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.fragment, 'abcd');
+      expect(route.args?.uri?.path, '/list');
+      expect(route.args?.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.args?.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.args?.fragment, 'abcd');
+    });
+
+    test('should retrieve route /mock/list#abcd', () async {
+      final route = await parse.selectRoute('/list#abcd', ModuleMock());
+      expect(route, isNotNull);
+      expect(route.child!(context, null), isA<ListView>());
+      expect(route.path, '/list#abcd');
+      expect(route.uri?.path, '/list');
+      expect(route.queryParams, {});
+      expect(route.fragment, 'abcd');
+      expect(route.args?.uri?.path, '/list');
+      expect(route.args?.queryParams, {});
+      expect(route.args?.fragment, 'abcd');
+    });
+
     test('should retrive Widcard route when not exist path', () async {
       final route = await parse.selectRoute('/paulo', ModuleMock());
+      expect(route, isNotNull);
+      expect(route.child!(context, null), isA<FlutterLogo>());
+    });
+
+    test('should retrive Widcard route when path with query params doesnt exist', () async {
+      final route = await parse.selectRoute('/paulo?adbc=1234', ModuleMock());
+      expect(route, isNotNull);
+      expect(route.child!(context, null), isA<FlutterLogo>());
+    });
+
+    test('should retrive Widcard route when path with fragment doesnt exist', () async {
+      final route = await parse.selectRoute('/paulo#adbc=1234', ModuleMock());
       expect(route, isNotNull);
       expect(route.child!(context, null), isA<FlutterLogo>());
     });
@@ -75,6 +130,10 @@ main() {
       expect(route.queryParams, {'id':'1234','type':'DYN'});
       expect(route.queryParamsAll, {'id':['1234'],'type':['DYN']});
       expect(route.fragment, '');
+      expect(route.args?.uri?.path, '/mock/list');
+      expect(route.args?.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.args?.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.args?.fragment, '');
     });
 
     test('should retrieve route /mock/list?id=1234&type=DYN#abcd', () async {
@@ -86,6 +145,10 @@ main() {
       expect(route.queryParams, {'id':'1234','type':'DYN'});
       expect(route.queryParamsAll, {'id':['1234'],'type':['DYN']});
       expect(route.fragment, 'abcd');
+      expect(route.args?.uri?.path, '/mock/list');
+      expect(route.args?.queryParams, {'id':'1234','type':'DYN'});
+      expect(route.args?.queryParamsAll, {'id':['1234'],'type':['DYN']});
+      expect(route.args?.fragment, 'abcd');
     });
 
     test('should retrieve route /mock/list#abcd', () async {
@@ -96,6 +159,9 @@ main() {
       expect(route.uri?.path, '/mock/list');
       expect(route.queryParams, {});
       expect(route.fragment, 'abcd');
+      expect(route.args?.uri?.path, '/mock/list');
+      expect(route.args?.queryParams, {});
+      expect(route.args?.fragment, 'abcd');
     });
 
     test('should retrive dynamic route /mock/list/:id', () async {
@@ -113,6 +179,14 @@ main() {
 
     test('should guard route /mock/listguarded', () async {
       expect(parse.selectRoute('/mock/listguarded', ModuleMock()), throwsA(isA<ModularError>()));
+    });
+
+    test('should guard route /mock/listguarded with params', () async {
+      expect(parse.selectRoute('/mock/listguarded?abc=def', ModuleMock()), throwsA(isA<ModularError>()));
+    });
+
+    test('should guard route /mock/listguarded with fragment', () async {
+      expect(parse.selectRoute('/mock/listguarded#abc=def', ModuleMock()), throwsA(isA<ModularError>()));
     });
 
     test('should guard route /guarded/list', () async {


### PR DESCRIPTION
Hi,

So, this pull request addresses 2 issues i noticed. First, `ModularArguments.uri` was null which in turn meant `fragment`, `queryParams` and `queryParamsAll` were all empty. The tests didn't catch this becasue they were checking the route returned instead of `route.args` (I updated the tests too).

Secondly, the query params information did not exist in ```Modular.args``` because of `resolverPath(String routeName, String path)` method. It was removing the query params. i updated it to `Uri.toString`.