### PR TITLE
Added route generator

### DIFF
--- a/flutter_modular/lib/src/core/interfaces/modular_route.dart
+++ b/flutter_modular/lib/src/core/interfaces/modular_route.dart
@@ -8,7 +8,7 @@ import '../models/modular_arguments.dart';
 import 'child_module.dart';
 import 'route_guard.dart';
 
-typedef RouteBuilder<T> = MaterialPageRoute<T> Function(
+typedef RouteBuilder<T> = Route<T> Function(
     WidgetBuilder, RouteSettings);
 typedef ModularChild = Widget Function(
     BuildContext context, ModularArguments? args);

--- a/flutter_modular/lib/src/core/models/child_route.dart
+++ b/flutter_modular/lib/src/core/models/child_route.dart
@@ -14,6 +14,15 @@ class ChildRoute extends ModularRouteImpl {
     List<RouteGuard>? guards,
     TransitionType transition = TransitionType.defaultTransition,
     CustomTransition? customTransition,
+    RouteBuilder? routeGenerator,
     Duration duration = const Duration(milliseconds: 300),
-  }) : super(routerName, routerOutlet: [], duration: duration, child: child, customTransition: customTransition, children: children, guards: guards, transition: transition);
+  }) : super(routerName,
+            routerOutlet: [],
+            duration: duration,
+            child: child,
+            routeGenerator: routeGenerator,
+            customTransition: customTransition,
+            children: children,
+            guards: guards,
+            transition: transition);
 }

--- a/flutter_modular/lib/src/core/models/module_route.dart
+++ b/flutter_modular/lib/src/core/models/module_route.dart
@@ -10,8 +10,8 @@ class ModuleRoute extends ModularRouteImpl {
     required ChildModule module,
     List<RouteGuard>? guards,
     TransitionType transition = TransitionType.defaultTransition,
-    CustomTransition? customTransition,
+    CustomTransition? customTransition, RouteBuilder? routeGenerator,
     Duration duration = const Duration(milliseconds: 300),
   })  : assert(!routerName.contains('/:'), 'ModuleRoute should not contain dynamic route'),
-        super(routerName, routerOutlet: [], duration: duration, module: module, customTransition: customTransition, guards: guards, transition: transition);
+        super(routerName, routerOutlet: [], duration: duration,routeGenerator: routeGenerator, module: module, customTransition: customTransition, guards: guards, transition: transition);
 }

--- a/flutter_modular/lib/src/core/models/wildcard_route.dart
+++ b/flutter_modular/lib/src/core/models/wildcard_route.dart
@@ -13,6 +13,7 @@ class WildcardRoute extends ModularRouteImpl {
     List<RouteGuard>? guards,
     TransitionType transition = TransitionType.defaultTransition,
     CustomTransition? customTransition,
+    RouteBuilder? routeGenerator,
     Duration duration = const Duration(milliseconds: 300),
-  }) : super('**', routerOutlet: [], duration: duration, child: child, customTransition: customTransition, children: children, guards: guards, transition: transition);
+  }) : super('**', routerOutlet: [], duration: duration, child: child,routeGenerator: routeGenerator, customTransition: customTransition, children: children, guards: guards, transition: transition);
 }


### PR DESCRIPTION
Route generator was not being passed forward from the Route classes (`ChildRoute` etc) despite being implemented in `ModularPage `

```dart
else if (router.transition == TransitionType.defaultTransition) {
      // Helper function
      Widget widgetBuilder(BuildContext context) {
        //return disposablePage;
        return router.child!(context, router.args);
      }

      if (router.routeGenerator != null) {
        return router.routeGenerator!(widgetBuilder, this) as Route<T>;
      }
      return MaterialPageRoute<T>(
        settings: this,
        builder: widgetBuilder,
      );
    }
```