### PR TITLE
Fix/modules management

### DIFF
--- a/flutter_modular/lib/src/presenters/modular_impl.dart
+++ b/flutter_modular/lib/src/presenters/modular_impl.dart
@@ -51,7 +51,9 @@ class ModularImpl implements ModularInterface {
       module.instance();
       debugPrintModular("-- ${module.runtimeType.toString()} INITIALIZED");
     } else {
-      injectMap[name]?.paths.add(path);
+      // Add the new path only if the last path in paths list is different from the current one
+      final _paths = injectMap[name]?.paths;
+      if (_paths?.last != path) _paths?.add(path);
     }
   }
 

--- a/flutter_modular/lib/src/presenters/modular_impl.dart
+++ b/flutter_modular/lib/src/presenters/modular_impl.dart
@@ -122,6 +122,27 @@ class ModularImpl implements ModularInterface {
   @override
   bool dispose<B extends Object>() {
     var isDisposed = false;
+
+    /// Logic to check if bind is in the injectMap
+    /// Cause true -> continue the normal flow
+    /// Otherwise -> returns true to don't make dispose again
+    var check = false;
+
+    for (var key in injectMap.keys) {
+      if (check) break;
+
+      final _binds = injectMap[key]?.binds ?? [];
+
+      for (var element in _binds) {
+        if (element.inject is B Function(Inject<dynamic>)) {
+          check = true;
+          break;
+        }
+      }
+    }
+
+    if (!check) return true;
+
     for (var key in injectMap.keys) {
       if (_removeInjectableObject<B>(key)) {
         isDisposed = true;

--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -127,8 +127,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
     final trash = <String>[];
 
     injectMap.forEach((key, module) {
-      // Removes all duplicate routes
-      module.paths.removeWhere((element) => element == path);
+      module.paths.remove(path);
       if (path.characters.last == '/') {
         module.paths.remove('$path/'.replaceAll('//', ''));
       }

--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -50,7 +50,13 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
       key: ValueKey('url:${router.uri?.path ?? router.path}'),
       router: router,
     );
-    if (_pages.isEmpty) {
+
+    // Fix navigate function to don't replace a route of the same module
+    final modulePath = page.router.modulePath;
+    final valideModulePath = modulePath != null;
+    final routeIsInModule = page.router.path?.contains(modulePath!);
+
+    if (_pages.isEmpty || (valideModulePath && (routeIsInModule ?? false))) {
       _pages.add(page);
     } else {
       for (var p in _pages) {
@@ -121,7 +127,8 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
     final trash = <String>[];
 
     injectMap.forEach((key, module) {
-      module.paths.remove(path);
+      // Removes all duplicate routes
+      module.paths.removeWhere((element) => element == path);
       if (path.characters.last == '/') {
         module.paths.remove('$path/'.replaceAll('//', ''));
       }
@@ -243,6 +250,16 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
       final lastPage = _pages.last;
       _pages.last = page;
       rebuildPages();
+
+      // Remove inject of replaced module on pushReplacementNamed()
+      final _lastPagePath = lastPage.router.path;
+      if (_lastPagePath != null) {
+        removeInject(_lastPagePath);
+        for (var r in lastPage.router.routerOutlet) {
+          removeInject(r.path!);
+        }
+      }
+
       final result = await page.waitPop();
       lastPage.completePop(result);
       return result;


### PR DESCRIPTION
# Description

This PR tries to correct some problems and improve module management when using pushReplamecementNamed and navigate functions.

Fixes #320 #343 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

# How Has This Been Tested?

You can use [this](https://github.com/evandrmb/modular_without_login_dispose) repository to test the target flows that this PR aims to fix.

IMPORTANT: You have to remember to change the version of `flutter_modular` to the version of this PR.