### PR TITLE
fix navigate function to have two different behaviors

### DIFF
--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -51,28 +51,32 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
       router: router,
     );
 
-    // Fix navigate function to don't replace a route of the same module
-    final modulePath = page.router.modulePath;
-    final valideModulePath = modulePath != null;
-    final routeIsInModule = page.router.path?.contains(modulePath!);
-
-    if (_pages.isEmpty || (valideModulePath && (routeIsInModule ?? false))) {
+    if (_pages.isEmpty) {
       _pages.add(page);
     } else {
-      for (var p in _pages) {
-        p.completePop(null);
-        removeInject(p.router.path!);
-        for (var r in p.router.routerOutlet) {
-          removeInject(r.path!);
-        }
-      }
-      if (replaceAll) {
-        _pages = [page];
-      } else if (_pages.last.router.path != router.path) {
-        _pages.last = page;
+      // Fix navigate function to don't replace a route of the same module and
+      // replace all external modules
+      final _lastPageModule = _pages.last;
+      final routeIsInModule = _lastPageModule.router.modulePath == page.router.modulePath;
+
+      if (routeIsInModule) {
+        _pages.add(page);
       } else {
-        _pages.last.router.routerOutlet.clear();
-        _pages.last.router.routerOutlet.add(router.routerOutlet.last);
+        for (var p in _pages) {
+          p.completePop(null);
+          removeInject(p.router.path!);
+          for (var r in p.router.routerOutlet) {
+            removeInject(r.path!);
+          }
+        }
+        if (replaceAll) {
+          _pages = [page];
+        } else if (_pages.last.router.path != router.path) {
+          _pages.last = page;
+        } else {
+          _pages.last.router.routerOutlet.clear();
+          _pages.last.router.routerOutlet.add(router.routerOutlet.last);
+        }
       }
     }
 


### PR DESCRIPTION
# Description

This PR tries to correct the implementation of #363  on navigate() function. The changes cause the navigate function to have two different behaviors:

- When used within a module to navigate between the pages of that module, it works similarly to a pushNamed which just inserts the page into the navigation stack
- When used to navigate between modules, not internally, navigate replaces the entire navigation stack and navigates to the new module

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update