### PR TITLE
Replace all page in Modular.to.navigate

### DIFF
--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -100,7 +100,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
 
       var isDuplicatedPage = duplicatePage.router is! ModularRouteEmpty;
 
-      if (fromModular && (routeIsInModule && !isDuplicatedPage)) {
+      if (fromModular && routeIsInModule && !isDuplicatedPage && !replaceAll) {
         _pages.add(page);
       } else {
         if (fromModular) {


### PR DESCRIPTION
Fix Modular.to.navigate

Remove all pages when it's called