### PR TITLE
Set positional constructor param as optional

### DIFF
--- a/flutter_modular/lib/src/core/interfaces/route_guard.dart
+++ b/flutter_modular/lib/src/core/interfaces/route_guard.dart
@@ -4,7 +4,7 @@ import 'modular_route.dart';
 
 // ignore: one_member_abstracts
 abstract class RouteGuard {
-  RouteGuard(this.guardedRoute);
+  RouteGuard([this.guardedRoute]);
 
   final String? guardedRoute;
 


### PR DESCRIPTION
Right now the `RouteGuard` interface use `guardedRoute` param as nullable, but the constructor requires the positional param. 

The constructor `guardedRoute` param should also be optional.

Now you will be able to implements the interface without the constructor:
```dart
class MyGuard extends RouteGuard {
  @override
  Future<bool> canActivate(String path, ModularRoute router) async {
    // TODO: implement canActivate
    throw UnimplementedError();
  }
}
```