### PR TITLE
Set optional generic type on Pop and MaybePop

### DIFF
--- a/flutter_modular/lib/src/core/interfaces/modular_navigator_interface.dart
+++ b/flutter_modular/lib/src/core/interfaces/modular_navigator_interface.dart
@@ -65,7 +65,7 @@ abstract class IModularNavigator implements Listenable {
   /// ```
   /// Modular.to.pop();
   /// ```
-  void pop<T extends Object>([T result]);
+  void pop<T extends Object?>([T result]);
 
   /// The initial route cannot be popped off the navigator, which implies that
   /// this function returns true only if popping the navigator would not remove
@@ -83,7 +83,7 @@ abstract class IModularNavigator implements Listenable {
   /// ```
   /// Modular.to.maybePop();
   /// ```
-  Future<bool> maybePop<T extends Object>([T result]);
+  Future<bool> maybePop<T extends Object?>([T result]);
 
   ///Calls pop repeatedly on the navigator that most tightly encloses the given
   ///context until the predicate returns true.

--- a/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_router_delegate.dart
@@ -339,10 +339,10 @@ class ModularRouterDelegate extends RouterDelegate<ModularRoute>
   }
 
   @override
-  Future<bool> maybePop<T extends Object>([T? result]) => navigator.maybePop(result);
+  Future<bool> maybePop<T extends Object?>([T? result]) => navigator.maybePop(result);
 
   @override
-  void pop<T extends Object>([T? result]) => navigator.pop(result);
+  void pop<T extends Object?>([T? result]) => navigator.pop(result);
 
   @override
   void popUntil(bool Function(Route) predicate) {


### PR DESCRIPTION
This PR is a fix on `Modular Navigator interface`, to support optional generic type on `Modular.to.pop()` and `Modular.to.maybePop()` to match Navigator's methods.

before:
```dart
final String? foo = null;
Modular.to.pop(foo) // Error!, Tried to infer 'Null' for 'T' which doesn't work..
```

after: 
```dart
final String? foo = null;
Modular.to.pop(foo) // Works!
```