### PR TITLE
Fix rebinding WidgetModules then the same module type used

### DIFF
--- a/flutter_modular/lib/src/core/interfaces/modular_interface.dart
+++ b/flutter_modular/lib/src/core/interfaces/modular_interface.dart
@@ -18,7 +18,7 @@ abstract class ModularInterface {
   @visibleForTesting
   void overrideBinds(List<Bind> binds);
   void init(Module module);
-  void bindModule(Module module, [String path]);
+  void bindModule(Module module, {String path, bool rebindDuplicates});
   void debugPrintModular(String text);
   T bind<T extends Object>(Bind<T> bind);
   Future<void> isModuleReady<M>();

--- a/flutter_modular/lib/src/presenters/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenters/navigation/modular_route_information_parser.dart
@@ -112,7 +112,7 @@ class ModularRouteInformationParser extends RouteInformationParser<ModularRoute>
           );
         }
         if (route.module != null) {
-          Modular.bindModule(route.module!, uri.path);
+          Modular.bindModule(route.module!, path: uri.path);
         }
         return router;
       }
@@ -139,7 +139,7 @@ class ModularRouteInformationParser extends RouteInformationParser<ModularRoute>
       }
 
       if (parseRoute.currentModule != null) {
-        Modular.bindModule(parseRoute.currentModule!, uri.path);
+        Modular.bindModule(parseRoute.currentModule!, path: uri.path);
       }
       return parseRoute;
     }

--- a/flutter_modular/lib/src/presenters/widgets/widget_module.dart
+++ b/flutter_modular/lib/src/presenters/widgets/widget_module.dart
@@ -50,8 +50,7 @@ abstract class WidgetModule extends StatelessWidget implements Module {
   }
 
   @override
-  T? getBind<T extends Object>(
-      {Map<String, dynamic>? params, List<Type> typesInRequest = const []}) {
+  T? getBind<T extends Object>({Map<String, dynamic>? params, List<Type> typesInRequest = const []}) {
     return _fakeModule.getBind<T>(typesInRequest: typesInRequest);
   }
 
@@ -98,8 +97,7 @@ class ModularProvider extends StatefulWidget {
   final Module module;
   final Widget child;
 
-  const ModularProvider({Key? key, required this.module, required this.child})
-      : super(key: key);
+  const ModularProvider({Key? key, required this.module, required this.child}) : super(key: key);
 
   @override
   _ModularProviderState createState() => _ModularProviderState();

--- a/flutter_modular/lib/src/presenters/widgets/widget_module.dart
+++ b/flutter_modular/lib/src/presenters/widgets/widget_module.dart
@@ -107,7 +107,7 @@ class _ModularProviderState extends State<ModularProvider> {
   @override
   void initState() {
     super.initState();
-    Modular.bindModule(widget.module);
+    Modular.bindModule(widget.module, rebindDuplicates: true);
   }
 
   @override

--- a/flutter_modular/lib/src/presenters/widgets/widget_module.dart
+++ b/flutter_modular/lib/src/presenters/widgets/widget_module.dart
@@ -50,7 +50,8 @@ abstract class WidgetModule extends StatelessWidget implements Module {
   }
 
   @override
-  T? getBind<T extends Object>({Map<String, dynamic>? params, List<Type> typesInRequest = const []}) {
+  T? getBind<T extends Object>(
+      {Map<String, dynamic>? params, List<Type> typesInRequest = const []}) {
     return _fakeModule.getBind<T>(typesInRequest: typesInRequest);
   }
 
@@ -97,7 +98,8 @@ class ModularProvider extends StatefulWidget {
   final Module module;
   final Widget child;
 
-  const ModularProvider({Key? key, required this.module, required this.child}) : super(key: key);
+  const ModularProvider({Key? key, required this.module, required this.child})
+      : super(key: key);
 
   @override
   _ModularProviderState createState() => _ModularProviderState();
@@ -107,8 +109,7 @@ class _ModularProviderState extends State<ModularProvider> {
   @override
   void initState() {
     super.initState();
-    // Modular.addCoreInit(widget.module);
-    _debugPrintModular("-- ${widget.module.runtimeType} INITIALIZED");
+    Modular.bindModule(widget.module);
   }
 
   @override
@@ -118,8 +119,8 @@ class _ModularProviderState extends State<ModularProvider> {
 
   @override
   void dispose() {
+    widget.module.cleanInjects();
     super.dispose();
-    // Modular.removeModule(widget.module);
     _debugPrintModular("-- ${widget.module.runtimeType} DISPOSED");
   }
 }


### PR DESCRIPTION
I made updates on this PR https://github.com/Flutterando/modular/pull/492

According to my comment https://github.com/Flutterando/modular/pull/492#issuecomment-886904382 `WidgetModule` still has a bug when we have two modules of the same type bound as siblings in some tab view.

But my changes has a compatibility breaking problem by changing method signature from:
```dart
void bindModule(Module module, [String path = '']);
```
to 
```dart
void bindModule(Module module, {String path, bool rebindDuplicates});
```
