### PR TITLE
Fix replace binds from initModule method (flutter_modular_test).

### DIFF
--- a/flutter_modular_test/lib/flutter_modular_test.dart
+++ b/flutter_modular_test/lib/flutter_modular_test.dart
@@ -10,7 +10,7 @@ void initModule(Module module, {List<Bind<Object>> replaceBinds = const [], bool
       return item.runtimeType == dep.runtimeType;
     }, orElse: () => BindEmpty());
     if (dep is! BindEmpty) {
-      module.binds[i] = dep;
+      module.getProcessBinds()[i] = dep;
     }
   }
   //module.changeBinds(changedList);


### PR DESCRIPTION
As each Module implementation returns a new bind list instance, using return value from binds getter method doesn't work.