### PR TITLE
Make singleton bindings factories

### DIFF
--- a/flutter_modular/lib/src/flutter_modular_module.dart
+++ b/flutter_modular/lib/src/flutter_modular_module.dart
@@ -55,17 +55,17 @@ class FlutterModularModule extends Module {
         Bind.factory<ReportPush>((i) => ReportPushImpl(i())),
         Bind.factory<ReassembleTracker>((i) => ReassembleTrackerImpl(i())),
         //presenter
-        Bind.singleton<ModularRouteInformationParser>((i) =>
+        Bind.factory<ModularRouteInformationParser>((i) =>
             ModularRouteInformationParser(
                 getRoute: i(),
                 getArguments: i(),
                 setArguments: i(),
                 reportPush: i())),
-        Bind.singleton<ModularRouterDelegate>((i) => ModularRouterDelegate(
+        Bind.factory<ModularRouterDelegate>((i) => ModularRouterDelegate(
             parser: i(),
             navigatorKey: GlobalKey<NavigatorState>(),
             reportPop: i())),
-        Bind.lazySingleton<IModularBase>((i) => ModularBase(
+        Bind.factory<IModularBase>((i) => ModularBase(
             reassembleTracker: i(),
             disposeBind: i(),
             finishModule: i(),


### PR DESCRIPTION
We have a modular part that is shown inside a full Flutter app. When we updated from 3.x to 4.x our app broke. When going to the modular page everything is fine. But when going back and to the page again it crashes. 

When pressing back and leaving the page ModularBase.destroy() is called. When going into the page again ModularBase.init is called, but ModularBase.get fails and goes to `throw left;`. 

I found that in flutter_modular_module almost everything is registered as factories, but IModularBase is registered as singleton. Therefore it is disposed, but never recreated. When changing that to a factory everything seems to work fine for us. It looks reasonable to also make ModularRouteInformationParser and ModularRouterDelegate a factory.

If this is not a proper solution I'd like to know why it is a singleton and what we might be doing wrong. Our main app is just a normal Flutter app. The modular component is a MaterialApp(...).modular()


It looks like there are some issues already posted that might be related to this as well.

**Edit: This fix does introduce a new bug for us which I'm investigating.**