### PR TITLE
Example code changed

### DIFF
--- a/doc/docs/flutter_modular/test.md
+++ b/doc/docs/flutter_modular/test.md
@@ -12,7 +12,7 @@ In this session we'll learn how to do this.
 We can replace the navigation object with a Mock/Fake by injecting the **Modular.navigatorDelegate** property:
 
 ```dart
-class ModularNavigateMock extends Mock implements IModularNavigate {}
+class ModularNavigateMock extends Mock implements IModularNavigator {}
 
 void main(){
     final navigate = ModularNavigateMock();


### PR DESCRIPTION
Example code changed. ModularNavigateMock, in flutter modular 4.2.0 should implements from IModularNavigator instead IModularNavigate.