### PR TITLE
Pass-through MateiralApp configuration

### DIFF
--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -93,6 +93,8 @@ extension ModularExtensionMaterial on MaterialApp {
       shortcuts: shortcuts,
       actions: actions,
       restorationScopeId: restorationScopeId,
+      scrollBehavior: scrollBehavior,
+      useInheritedMediaQuery: useInheritedMediaQuery,
       routeInformationParser: injector.get<ModularRouteInformationParser>(),
       routerDelegate: injector.get<ModularRouterDelegate>(),
     );


### PR DESCRIPTION
In Flutter 2.5 new parameters for the MaterialApp has been provided, this PR fix modular pass-through parameters to the MaterialApp.

Source: https://docs.flutter.dev/release/breaking-changes/default-scroll-behavior-drag
