### PR TITLE
Fix WidgetModules not being disposed

### DIFF
--- a/flutter_modular/lib/src/domain/services/module_service.dart
+++ b/flutter_modular/lib/src/domain/services/module_service.dart
@@ -6,7 +6,7 @@ import 'package:flutter_modular/src/shared/either.dart';
 abstract class ModuleService {
   Either<ModularError, Unit> start(RouteContext module);
   Either<ModularError, Unit> bind(BindContext module);
-  Either<ModularError, Unit> unbind<T extends BindContext>();
+  Either<ModularError, Unit> unbind<T extends BindContext>({Type? type});
   Either<ModularError, Unit> finish();
   Future<Either<ModularError, bool>> isModuleReady<M extends Module>();
 }

--- a/flutter_modular/lib/src/domain/usecases/unbind_module.dart
+++ b/flutter_modular/lib/src/domain/usecases/unbind_module.dart
@@ -3,7 +3,7 @@ import 'package:flutter_modular/src/shared/either.dart';
 import 'package:flutter_modular/src/domain/services/module_service.dart';
 
 abstract class UnbindModule {
-  Either<ModularError, Unit> call<T extends BindContext>();
+  Either<ModularError, Unit> call<T extends BindContext>({Type? type});
 }
 
 class UnbindModuleImpl implements UnbindModule {
@@ -12,7 +12,7 @@ class UnbindModuleImpl implements UnbindModule {
   UnbindModuleImpl(this.moduleService);
 
   @override
-  Either<ModularError, Unit> call<T extends BindContext>() {
-    return moduleService.unbind<T>();
+  Either<ModularError, Unit> call<T extends BindContext>({Type? type}) {
+    return moduleService.unbind<T>(type: type);
   }
 }

--- a/flutter_modular/lib/src/infra/services/module_service_impl.dart
+++ b/flutter_modular/lib/src/infra/services/module_service_impl.dart
@@ -32,8 +32,8 @@ class ModuleServiceImpl extends ModuleService {
   }
 
   @override
-  Either<ModularError, Unit> unbind<T extends BindContext>() {
-    tracker.injector.removeBindContext<T>();
+  Either<ModularError, Unit> unbind<T extends BindContext>({Type? type}) {
+    tracker.injector.removeBindContext<T>(type: type);
     return right(unit);
   }
 }

--- a/flutter_modular/lib/src/presenter/widgets/widget_module.dart
+++ b/flutter_modular/lib/src/presenter/widgets/widget_module.dart
@@ -109,6 +109,6 @@ class _ModularProviderState<T extends BindContext>
   @override
   void dispose() {
     super.dispose();
-    injector.get<UnbindModule>().call<T>();
+    injector.get<UnbindModule>().call<T>(type: widget.module.runtimeType);
   }
 }

--- a/modular_core/lib/src/di/injector.dart
+++ b/modular_core/lib/src/di/injector.dart
@@ -124,8 +124,8 @@ class InjectorImpl<T> implements Injector<T> {
   }
 
   @mustCallSuper
-  void removeBindContext<T extends BindContext>() {
-    final module = _allBindContexts.remove(_getType<T>());
+  void removeBindContext<T extends BindContext>({Type? type}) {
+    final module = _allBindContexts.remove(type ?? _getType<T>());
     if (module != null) {
       module.dispose();
       debugPrint("-- ${module.runtimeType} DISPOSED");

--- a/modular_interfaces/lib/src/di/injector.dart
+++ b/modular_interfaces/lib/src/di/injector.dart
@@ -27,7 +27,7 @@ abstract class Injector<T> {
   void destroy();
 
   /// remove [BindContext] by [Type]
-  void removeBindContext<T extends BindContext>();
+  void removeBindContext<T extends BindContext>({Type? type});
 
   /// checks if all asynchronous binds are ready to be used synchronously of all BindContext of Tree.
   Future<bool> isModuleReady<M extends BindContext>();


### PR DESCRIPTION
Adiciona um parâmetro de tipo para todas as classes envolvidas no dispose das binds do WidgetModule

Dessa forma, o removeBindContext consegue encontrar o tipo correto do WidgetModule sendo disposed e elimina as binds quando deveria

Resolve #632  