### PR TITLE
4.5.0

### DIFF
--- a/doc/docs/flutter_modular/module.md
+++ b/doc/docs/flutter_modular/module.md
@@ -32,10 +32,12 @@ void main(){
 
 class AppWidget extends StatelessWidget {
   Widget build(BuildContext context){
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'My Smart App',
       theme: ThemeData(primarySwatch: Colors.blue),
-    ).modular(); //added by extension 
+      routeInformationParser: Modular.routeInformationParser,
+      routerDelegate: Modular.routerDelegate,
+    ); //added by extension 
   }
 }
 

--- a/doc/docs/flutter_modular/navegation.md
+++ b/doc/docs/flutter_modular/navegation.md
@@ -25,7 +25,9 @@ class AppWidget extends StatelessWidget {
     return MaterialApp(
       title: 'My Smart App',
       theme: ThemeData(primarySwatch: Colors.blue),
-    ).modular(); //added by extension
+      routeInformationParser: Modular.routeInformationParser,
+      routerDelegate: Modular.routerDelegate,
+    ); //added by extension
   }
 }
 
@@ -285,11 +287,14 @@ void main() {
 
 class AppWidget extends StatelessWidget {
   Widget build(BuildContext context) {
-    return MaterialApp(
+    Modular.setInitialRoute('/page1');
+
+    return MaterialApp.router(
       title: 'My Smart App',
       theme: ThemeData(primarySwatch: Colors.blue),
-      initialRoute: '/page1',
-    ).modular();
+      routeInformationParser: Modular.routeInformationParser,
+      routerDelegate: Modular.routerDelegate,
+    );
   }
 }
 

--- a/doc/docs/flutter_modular/start.md
+++ b/doc/docs/flutter_modular/start.md
@@ -144,7 +144,7 @@ The main Widget's function is to instantiate the MaterialApp or CupertinoApp.
 
 In these main Widgets it's also necessary to set the custom route system. For this next snippet we'll use **MaterialApp**, but the process is exactly the same for CupertinoApp.
 
-```dart title="lib/main.dart" {8-15}
+```dart title="lib/main.dart" {9-16}
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -154,7 +154,7 @@ void main(){
 
 class AppWidget extends StatelessWidget {
   Widget build(BuildContext context){
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'My Smart App',
       theme: ThemeData(primarySwatch: Colors.blue),
       routeInformationParser: Modular.routeInformationParser,
@@ -185,6 +185,20 @@ class HomePage extends StatelessWidget {
 }
 ```
 
-Here we create a Widget called **AppWidget** containing an instance of **MaterialApp**. Note that in the end, we call **.modular()** method that was added to **MaterialApp** through an extension.
+Here we create a Widget called **AppWidget** containing an instance of **MaterialApp.router**. 
+
+
+## Support methods
+
+Navigator 2.0 made Flutter's routing system more dynamic, but some information, previously passed in MaterialApp or CupertinoApp, has been removed, and it will be necessary to configure it using Modular's own support methods.
+
+```dart
+Modular.setNavigatorKey(myNavigatorKey);
+
+Modular.setObservers([myObserver]);
+
+Modular.setInitialRoute('/home');
+```
+
 
 That's enough to run a Modular app. In the next steps let's explore navigation.

--- a/doc/docs/flutter_modular/widgets.md
+++ b/doc/docs/flutter_modular/widgets.md
@@ -66,11 +66,14 @@ void main() {
 
 class AppWidget extends StatelessWidget {
   Widget build(BuildContext context) {
-    return MaterialApp(
+    Modular.setInitialRoute('/page1');
+
+    return MaterialApp.router(
       title: 'My Smart App',
       theme: ThemeData(primarySwatch: Colors.blue),
-      initialRoute: '/page1',
-    ).modular();
+      routeInformationParser: Modular.routeInformationParser,
+      routerDelegate: Modular.routerDelegate,
+    );
   }
 }
 

--- a/flutter_modular/CHANGELOG.md
+++ b/flutter_modular/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [4.4.1] - 2022-02-18
+## [4.5.0] - 2022-02-22
 
 - @Deprecated: `.modular()` extension.
   Use instead:
@@ -9,7 +9,13 @@
     );
 
   ```
-- Fix bugs.
+- Added `Modular.setInitialRoute`.
+- Added `Modular.setObservers`.
+- Added `Modular.setNavigatorKey`.
+
+## [4.4.1] - 2022-02-18
+
+- Fix bugs in lints.
 
 ## [4.4.0+1] - 2022-01-22
 

--- a/flutter_modular/analysis_options.yaml
+++ b/flutter_modular/analysis_options.yaml
@@ -22,6 +22,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
+    no_logic_in_create_state: false
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 

--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -6,7 +6,6 @@ import 'package:flutter_modular/src/flutter_modular_module.dart';
 import 'package:modular_core/modular_core.dart';
 
 import 'src/domain/usecases/get_arguments.dart';
-import 'src/presenter/models/modular_navigator.dart';
 import 'src/presenter/modular_base.dart';
 import 'src/presenter/navigation/modular_page.dart';
 import 'src/presenter/navigation/modular_router_delegate.dart';
@@ -52,9 +51,6 @@ void cleanGlobals() {
   cleanInjector();
 }
 
-@visibleForTesting
-String initialRouteDeclaredInMaterialApp = '/';
-
 extension ModularExtensionMaterial on MaterialApp {
   ///Use instead:
   ///```dart
@@ -66,13 +62,9 @@ extension ModularExtensionMaterial on MaterialApp {
   ///```
   @Deprecated('Use **MaterialApp.router** instead')
   MaterialApp modular() {
-    injector
-        .get<IModularNavigator>()
-        .setObserver(navigatorObservers ?? <NavigatorObserver>[]);
-
-    injector.get<IModularNavigator>().setNavigatorKey(navigatorKey);
-
-    initialRouteDeclaredInMaterialApp = initialRoute ?? '/';
+    Modular.setObservers(navigatorObservers ?? []);
+    Modular.setNavigatorKey(navigatorKey);
+    Modular.setInitialRoute(initialRoute ?? '/');
 
     final app = MaterialApp.router(
       key: key,
@@ -121,15 +113,11 @@ extension ModularExtensionCupertino on CupertinoApp {
   ///```
   @Deprecated('Use CupertinoApp.router instead')
   CupertinoApp modular() {
-    injector
-        .get<IModularNavigator>()
-        .setObserver(navigatorObservers ?? <NavigatorObserver>[]);
-
-    injector.get<IModularNavigator>().setNavigatorKey(navigatorKey);
+    Modular.setObservers(navigatorObservers ?? []);
+    Modular.setNavigatorKey(navigatorKey);
+    Modular.setInitialRoute(initialRoute ?? '/');
 
     (injector.get<IModularBase>() as ModularBase).flags.isCupertino = true;
-
-    initialRouteDeclaredInMaterialApp = initialRoute ?? '/';
 
     final app = CupertinoApp.router(
       key: key,

--- a/flutter_modular/lib/src/presenter/models/modular_navigator.dart
+++ b/flutter_modular/lib/src/presenter/models/modular_navigator.dart
@@ -113,7 +113,7 @@ abstract class IModularNavigator implements Listenable {
   /// ```
   void navigate(String path, {dynamic arguments});
 
-  void setObserver(List<NavigatorObserver> navigatorObservers);
+  void setObservers(List<NavigatorObserver> navigatorObservers);
 
   void setNavigatorKey(GlobalKey<NavigatorState>? navigatorkey);
 }

--- a/flutter_modular/lib/src/presenter/modular_base.dart
+++ b/flutter_modular/lib/src/presenter/modular_base.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import '../domain/usecases/get_arguments.dart';
 import '../domain/usecases/reassemble_tracker.dart';
 import 'package:modular_core/modular_core.dart';
@@ -69,6 +69,18 @@ abstract class IModularBase {
 
   /// Navigator 2.0 initializator: RouterDelegate
   ModularRouterDelegate get routerDelegate;
+
+  /// Change the starting route path
+  void setInitialRoute(String initialRoute);
+
+  /// Change a list of NavigatorObserver objects
+  void setObservers(List<NavigatorObserver> navigatorObservers);
+
+  /// Change the navigatorKey
+  void setNavigatorKey(GlobalKey<NavigatorState>? key);
+
+  @visibleForTesting
+  String get initialRoutePath;
 }
 
 class ModularBase implements IModularBase {
@@ -89,6 +101,12 @@ class ModularBase implements IModularBase {
   IModularNavigator? navigatorDelegate;
 
   bool _moduleHasBeenStarted = false;
+
+  String _initialRoutePath = '/';
+
+  @visibleForTesting
+  @override
+  String get initialRoutePath => _initialRoutePath;
 
   ModularBase({
     required this.routeInformationParser,
@@ -189,5 +207,20 @@ class ModularBase implements IModularBase {
   @override
   void reassemble() {
     reassembleTracker();
+  }
+
+  @override
+  void setInitialRoute(String value) {
+    _initialRoutePath = value;
+  }
+
+  @override
+  void setNavigatorKey(GlobalKey<NavigatorState>? key) {
+    routerDelegate.setNavigatorKey(key);
+  }
+
+  @override
+  void setObservers(List<NavigatorObserver> navigatorObservers) {
+    routerDelegate.setObservers(navigatorObservers);
   }
 }

--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -35,7 +35,7 @@ class ModularRouteInformationParser
       if (routeInformation.location == null ||
           routeInformation.location == '/') {
         // ignore: invalid_use_of_visible_for_testing_member
-        path = initialRouteDeclaredInMaterialApp;
+        path = Modular.initialRoutePath;
       } else {
         path = routeInformation.location!;
       }
@@ -43,7 +43,7 @@ class ModularRouteInformationParser
       _firstParse = true;
     } else {
       // ignore: invalid_use_of_visible_for_testing_member
-      path = routeInformation.location ?? initialRouteDeclaredInMaterialApp;
+      path = routeInformation.location ?? Modular.initialRoutePath;
     }
 
     return await selectBook(path);

--- a/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
@@ -51,7 +51,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularBook>
   }
 
   @override
-  void setObserver(List<NavigatorObserver> navigatorObservers) {
+  void setObservers(List<NavigatorObserver> navigatorObservers) {
     observers = navigatorObservers;
     notifyListeners();
   }

--- a/flutter_modular/pubspec.yaml
+++ b/flutter_modular/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_modular
 description: Smart project structure with dependency injection and route management
-version: 4.4.1
+version: 4.5.0
 homepage: https://github.com/Flutterando/modular
 
 environment:

--- a/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
@@ -58,7 +58,7 @@ void main() {
   });
 
   test('setObserver', () {
-    delegate.setObserver([NavigatorObserver()]);
+    delegate.setObservers([NavigatorObserver()]);
     expect(delegate.observers.length, 1);
   });
 


### PR DESCRIPTION
- @Deprecated: `.modular()` extension.
  Use instead:
  ```dart
    return MaterialApp.router(
      routeInformationParser: Modular.routeInformationParser,
      routerDelegate: Modular.routerDelegate,
    );

  ```
- Added `Modular.setInitialRoute`.
- Added `Modular.setObservers`.
- Added `Modular.setNavigatorKey`.