### PR TITLE
 fix: change Route.path to Route.patch

### DIFF
--- a/shelf_modular/lib/src/presenter/models/route.dart
+++ b/shelf_modular/lib/src/presenter/models/route.dart
@@ -55,7 +55,7 @@ class Route extends ModularRouteImpl {
       middlewares: middlewares,
     );
   }
-  factory Route.path(
+  factory Route.patch(
     String name,
     Function handler, {
     List<ModularMiddleware> middlewares = const [],

--- a/shelf_modular/test/src/presenter/models/route_test.dart
+++ b/shelf_modular/test/src/presenter/models/route_test.dart
@@ -19,7 +19,7 @@ void main() {
     expect(route.schema, 'DELETE');
   });
   test('route PATCH', () {
-    final route = Route.path('/', () {});
+    final route = Route.patch('/', () {});
     expect(route.name, '/');
     expect(route.schema, 'PATCH');
   });


### PR DESCRIPTION
# Description

change Route.path to Route.patch in route.dart of modular_shelf because the rest method's name was wrong

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
