### PR TITLE
feat: Add observers to RouterOutlet

### DIFF
--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -62,7 +62,8 @@ extension InjectorExtends on Injector {
 
 /// It acts as a Nested Browser that will be populated by the children of this route.
 class RouterOutlet extends StatefulWidget {
-  const RouterOutlet({Key? key}) : super(key: key);
+  final List<NavigatorObserver>? observers;
+  const RouterOutlet({Key? key, this.observers}) : super(key: key);
 
   @override
   RouterOutletState createState() => RouterOutletState();
@@ -72,6 +73,9 @@ class RouterOutletState extends State<RouterOutlet> {
   late GlobalKey<NavigatorState> navigatorKey;
   RouterOutletDelegate? delegate;
   late ChildBackButtonDispatcher _backButtonDispatcher;
+
+  List<NavigatorObserver> get currentObservers =>
+      widget.observers ?? <NavigatorObserver>[];
 
   @override
   void initState() {
@@ -91,7 +95,7 @@ class RouterOutletState extends State<RouterOutlet> {
     super.didChangeDependencies();
     final modal = (ModalRoute.of(context)?.settings as ModularPage);
     delegate ??= RouterOutletDelegate(modal.route.uri.toString(),
-        injector.get<ModularRouterDelegate>(), navigatorKey);
+        injector.get<ModularRouterDelegate>(), navigatorKey, currentObservers);
     final router = Router.of(context);
     _backButtonDispatcher =
         router.backButtonDispatcher!.createChildBackButtonDispatcher();

--- a/flutter_modular/lib/src/presenter/navigation/router_outlet_delegate.dart
+++ b/flutter_modular/lib/src/presenter/navigation/router_outlet_delegate.dart
@@ -15,9 +15,10 @@ class RouterOutletDelegate extends RouterDelegate<ParallelRoute>
 
   final ModularRouterDelegate modularRouterDelegate;
   final String path;
+  final List<NavigatorObserver>? observers;
 
   RouterOutletDelegate(
-      this.path, this.modularRouterDelegate, this.navigatorKey);
+      this.path, this.modularRouterDelegate, this.navigatorKey, this.observers);
 
   List<ModularPage> _getPages() {
     return modularRouterDelegate.currentConfiguration
@@ -35,6 +36,7 @@ class RouterOutletDelegate extends RouterDelegate<ParallelRoute>
             key: navigatorKey,
             modularBase: Modular,
             pages: _pages,
+            observers: observers ?? [],
             onPopPage: modularRouterDelegate.onPopPage,
           );
   }

--- a/flutter_modular/test/src/presenter/navigation/router_outlet_delegate_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/router_outlet_delegate_test.dart
@@ -21,18 +21,23 @@ class NavigatorStateMock extends Mock implements NavigatorState {
   }
 }
 
+class NavigatorObserverMock extends Mock implements NavigatorObserver {}
+
 void main() {
   late ModularRouterDelegateMock modularRouterDelegateMock;
   late RouterOutletDelegate outlet;
   late NavigatorKeyMock<NavigatorState> key;
   late NavigatorStateMock navigatorState;
+  late NavigatorObserverMock navigatorObserver;
 
   setUp(() {
     modularRouterDelegateMock = ModularRouterDelegateMock();
     key = NavigatorKeyMock<NavigatorState>();
     navigatorState = NavigatorStateMock();
+    navigatorObserver = NavigatorObserverMock();
     when(() => key.currentState).thenReturn(navigatorState);
-    outlet = RouterOutletDelegate('outlet', modularRouterDelegateMock, key);
+    outlet = RouterOutletDelegate(
+        'outlet', modularRouterDelegateMock, key, [navigatorObserver]);
   });
 
   test('setNewRoutePath...', () {


### PR DESCRIPTION
# Description

Add observers to RouterOutlet so that nested routes can be observed.

```dart
 return Scaffold(
      appBar: AppBar(title: Text('Home Page')),
      body: Row(
        children: [
          leading,
          Container(width: 2, color: Colors.black45),
          Expanded(child: RouterOutlet(observers: [DebugPrintNavigationObserver(), SentryNavigationObserver()])),
        ],
      ),
    );
```

The parameter `observers` is optional.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

#738 #529 

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
