### PR TITLE
fix: #754 - setArguments is ignoring data passed in

### DIFF
--- a/flutter_modular/lib/src/presenter/modular_base.dart
+++ b/flutter_modular/lib/src/presenter/modular_base.dart
@@ -223,6 +223,6 @@ class ModularBase implements IModularBase {
 
   @override
   void setArguments(dynamic data) {
-    setArgumentsUsecase.call(args.copyWith(data: args));
+    setArgumentsUsecase.call(args.copyWith(data: data));
   }
 }

--- a/flutter_modular/test/src/presenter/modular_base_test.dart
+++ b/flutter_modular/test/src/presenter/modular_base_test.dart
@@ -2,14 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
-import 'package:flutter_modular/src/domain/usecases/reassemble_tracker.dart';
-import 'package:flutter_modular/src/domain/usecases/set_arguments.dart';
-import 'package:flutter_modular/src/presenter/errors/errors.dart';
-import 'package:flutter_modular/src/presenter/navigation/modular_route_information_parser.dart';
-import 'package:flutter_modular/src/presenter/navigation/modular_router_delegate.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:modular_core/modular_core.dart';
 import 'package:flutter_modular/src/domain/dtos/route_dto.dart';
 import 'package:flutter_modular/src/domain/errors/errors.dart';
 import 'package:flutter_modular/src/domain/usecases/dispose_bind.dart';
@@ -18,10 +10,18 @@ import 'package:flutter_modular/src/domain/usecases/get_arguments.dart';
 import 'package:flutter_modular/src/domain/usecases/get_bind.dart';
 import 'package:flutter_modular/src/domain/usecases/get_route.dart';
 import 'package:flutter_modular/src/domain/usecases/module_ready.dart';
+import 'package:flutter_modular/src/domain/usecases/reassemble_tracker.dart';
 import 'package:flutter_modular/src/domain/usecases/release_scoped_binds.dart';
+import 'package:flutter_modular/src/domain/usecases/set_arguments.dart';
 import 'package:flutter_modular/src/domain/usecases/start_module.dart';
+import 'package:flutter_modular/src/presenter/errors/errors.dart';
 import 'package:flutter_modular/src/presenter/modular_base.dart';
+import 'package:flutter_modular/src/presenter/navigation/modular_route_information_parser.dart';
+import 'package:flutter_modular/src/presenter/navigation/modular_router_delegate.dart';
 import 'package:flutter_modular/src/shared/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:modular_core/modular_core.dart';
 
 import '../mocks/mocks.dart';
 
@@ -165,7 +165,9 @@ void main() {
     when(() => getArguments.call()).thenReturn(right(ModularArguments.empty()));
     when(() => setArguments.call(any())).thenReturn(right(unit));
     modularBase.setArguments('args');
-    verify(() => setArguments.call(any())).called(1);
+    verify(() => setArguments.call(
+          any(that: predicate<ModularArguments>((it) => it.data == 'args')),
+        )).called(1);
   });
 }
 


### PR DESCRIPTION
# Description

This PR fix the issue #754 in flutter_modular/presenter/modular_base.dart

line 26 ignores the passed in `data` but mistakenly used `args`.

## Checklist

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

Fixes #754

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
