### PR TITLE
fix: change redirect route arguments

### DIFF
--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -120,16 +120,17 @@ class ModularRouteInformationParser
   }
 
   FutureOr<ParallelRoute> _routeSuccess(ModularRoute? route) async {
-    final arguments = getArguments().getOrElse((l) => ModularArguments.empty());
+    final modularArguments =
+        getArguments().getOrElse((l) => ModularArguments.empty());
     for (var middleware in route!.middlewares) {
-      route = await middleware.pos(route!, arguments);
+      route = await middleware.pos(route!, modularArguments);
       if (route == null) {
         break;
       }
     }
 
     if (route is RedirectRoute) {
-      route = await selectRoute(route.to, arguments: arguments);
+      route = await selectRoute(route.to, arguments: modularArguments.data);
     }
 
     if (route != null) {

--- a/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
@@ -107,7 +107,7 @@ void main() {
 
   test('selectRoute with RedirectRoute', () async {
     final redirect = RedirectRoute('/oo', to: '/test');
-    final args = ModularArguments.empty();
+    final modularArgument = ModularArguments.empty();
 
     final routeMock = ParallelRouteMock();
     when(() => routeMock.uri).thenReturn(Uri.parse('/test'));
@@ -130,11 +130,12 @@ void main() {
 
     when(() => getRoute.call(const RouteParmsDTO(url: '/oo')))
         .thenAnswer((_) async => right(redirect));
-    when(() => getRoute.call(RouteParmsDTO(url: '/test', arguments: args)))
+    when(() => getRoute
+            .call(RouteParmsDTO(url: '/test', arguments: modularArgument.data)))
         .thenAnswer((_) async => right(routeMock));
     when(() => getRoute.call(const RouteParmsDTO(url: '/')))
         .thenAnswer((_) async => right(routeParent));
-    when(() => getArguments.call()).thenReturn(right(args));
+    when(() => getArguments.call()).thenReturn(right(modularArgument));
 
     when(() => setArguments.call(any())).thenReturn(right(unit));
 
@@ -143,7 +144,6 @@ void main() {
     expect(book.chapters().first.name, '/');
     expect(book.chapters('/').first.name, '/test');
   });
-
   test('selectRoute with resolver route withless /', () async {
     final args = ModularArguments.empty();
 


### PR DESCRIPTION
# Description
When setting arguments using RedirectRoute, a ModularArguments is passed instead of the actual argument.

This caused the following error:
The following _TypeError was thrown building Builder:
type 'ModularArguments' is not a subtype of type 'XPTO'

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
