### PR TITLE
Fix: Solves the problem of a module with children that does not dispose

### DIFF
--- a/modular_core/lib/src/tracker.dart
+++ b/modular_core/lib/src/tracker.dart
@@ -193,7 +193,13 @@ class _Tracker implements Tracker {
         bindModule(module);
         printResolverFunc?.call('-- ${module.runtimeType} INITIALIZED');
       }
-      _disposeTags[key]!.add(route.uri.toString());
+      final routeUri = route.uri.toString();
+      if (_disposeTags[key]!.isNotEmpty && routeUri != '/') {
+        if (_disposeTags[key]!.contains(routeUri)) {
+          continue;
+        }
+      }
+      _disposeTags[key]!.add(routeUri);
     }
   }
 


### PR DESCRIPTION
# Description
Ao navegar para uma rota filha, a rota mãe também é colocada na pilha e acrescentada para ser descartada (`List _disposeTags`). O problema acontece quando navegamos para uma segunda rota folha, pois era acrescentada novamente a rota mãe para descarte, causando duplicidade, então a rota mãe nunca era descartada devido a existência de mais de uma ocorrência para descarte.

## Checklist
- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.

## Breaking Change
- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues
#902 
#899 
