### PR TITLE
fix: fix of a typo

### DIFF
--- a/doc/docs/flutter_modular/start.md
+++ b/doc/docs/flutter_modular/start.md
@@ -133,7 +133,7 @@ There are some ModularRoute types: **ChildRoute**, **ModuleRoute**, **RedirectRo
 **RedirectRoute**: Redirect to other route.<br />
 **WildcardRoute**: Default route in Module.<br /> <br />
 
-Inside the `routes(e);` method we can use: <br />
+Inside the `routes(r);` method we can use: <br />
 **r.child => ChildRoute**. <br />
 **r.module => ModuleRoute**. <br />
 **r.redirect => RedirectRoute**. <br />


### PR DESCRIPTION
I think that while explaining possibilities of routes() function there was a typo: "routes(e)" but "r" namespace is used later on.

# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
