### PR TITLE
fix: Prevent RouterOutlet to get priority.

### DIFF
--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -2,6 +2,7 @@ library flutter_modular_forked;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_modular/src/flutter_modular_module.dart';
 import 'package:modular_core/modular_core.dart';
 
@@ -98,9 +99,6 @@ class RouterOutletState extends State<RouterOutlet> {
   /// visible for test
   @visibleForTesting
   void listener() {
-    print(Modular.to.path);
-    final modal = ModalRoute.of(context)?.settings as ModularPage?;
-
     setState(() {});
   }
 
@@ -117,15 +115,20 @@ class RouterOutletState extends State<RouterOutlet> {
       _navigatorKey,
       currentObservers,
     );
-    if (!(modal?.route.children.any((e) => Modular.to.path.contains(e.name)) ??
-        true)) {
-      print('is not a children');
+
+    /// Prevent RouterOutlent to take back button priority
+    /// when the new named route, is not a children
+    if (_newRouteIsNotChildren(modal.route)) {
       _backButtonDispatcher = null;
       return;
     }
     final router = Router.of(context);
     _backButtonDispatcher = router.backButtonDispatcher //
         ?.createChildBackButtonDispatcher();
+  }
+
+  bool _newRouteIsNotChildren(ParallelRoute route) {
+    return !route.children.any((e) => Modular.to.path.contains(e.name));
   }
 
   @override

--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -1,4 +1,4 @@
-library flutter_modular_forked;
+library flutter_modular;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/flutter_modular/lib/flutter_modular.dart
+++ b/flutter_modular/lib/flutter_modular.dart
@@ -1,4 +1,4 @@
-library flutter_modular;
+library flutter_modular_forked;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -98,6 +98,9 @@ class RouterOutletState extends State<RouterOutlet> {
   /// visible for test
   @visibleForTesting
   void listener() {
+    print(Modular.to.path);
+    final modal = ModalRoute.of(context)?.settings as ModularPage?;
+
     setState(() {});
   }
 
@@ -114,6 +117,12 @@ class RouterOutletState extends State<RouterOutlet> {
       _navigatorKey,
       currentObservers,
     );
+    if (!(modal?.route.children.any((e) => Modular.to.path.contains(e.name)) ??
+        true)) {
+      print('is not a children');
+      _backButtonDispatcher = null;
+      return;
+    }
     final router = Router.of(context);
     _backButtonDispatcher = router.backButtonDispatcher //
         ?.createChildBackButtonDispatcher();


### PR DESCRIPTION
# Description

Prevent RouterOutlet to get priority over de backButton when the new push named route is not a child of any RouterOutlet route.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues
#920

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
