### PR TITLE
bug: missing line in _createExportedInjector

### DIFF
--- a/modular_core/lib/src/tracker.dart
+++ b/modular_core/lib/src/tracker.dart
@@ -264,6 +264,7 @@ class _Tracker implements Tracker {
     if (!_importedInjector.containsKey(importTag)) {
       exportedInject = _createInjector(importedModule, '${importTag}_Imported');
       importedModule.exportedBinds(exportedInject);
+      _importedInjector[importTag] = exportedInject;
     } else {
       exportedInject = _importedInjector[importTag]!;
     }


### PR DESCRIPTION
# Description
Para fazer o PR #911, eu fiz o fork do repositório do modular e alterei somente o arquivo `tracker.dart` do `modular_core`, que já foi mergeado, mas como o `modular_core` é um package separado, ainda é necessário publicá-lo em pub.dev para que o `flutter_modular` possa utilizá-lo.
Ao fazer testes após essa alteração, percebi que um novo problema acontece, mas que não tem nenhuma relação com minha alteração. 
Descobri que existia uma diferença entre código do `modular_core` que está na pub.dev (antes da minha alteração) em relação ao que está no repositório do modular atualmente (até a data que foi feito o último upload para a pub.dev). 
Uma linha apenas no método `_createExportedInjector` estava ausente e provocava um problema ao fazer um import de alguma dependência singleton/lazySingleton exportada, pois sempre criava uma nova instância.
Com este PR isto é resolvido e o `modular_core` já pode ser atualizado na pub.dev

## Breaking Change
- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.
