### PR TITLE
Fix: Popping a parent route should also pop all child routes

### DIFF
--- a/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
@@ -117,6 +117,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularBook>
     final parallel = page.route;
     parallel.popCallback?.call(result);
     currentConfiguration?.routes.remove(parallel);
+    currentConfiguration?.routes.removeWhere((element) => element.parent == parallel.uri.toString());
     if (currentConfiguration?.routes.indexWhere(
             (element) => element.uri.toString() == parallel.uri.toString()) ==
         -1) {

--- a/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
@@ -159,7 +159,45 @@ void main() {
     expect(delegate.currentConfiguration?.routes.length, 0);
     expect(delegate.navigateHistory, delegate.currentConfiguration?.routes);
   });
+  test('onPopPage with parent/child route', () {
+    final route = RouteMock();
+    final parallel = ParallelRouteMock();
+    when(() => parallel.uri).thenReturn(Uri.parse('/'));
+    final page = ModularPage(
+        route: parallel, args: ModularArguments.empty(), flags: ModularFlags());
+    when(() => route.didPop(null)).thenReturn(true);
+    when(() => route.settings).thenReturn(page);
+    when(() => route.isFirst).thenReturn(false);
 
+    when(() => reportPopMock.call(parallel)).thenReturn(const Success(unit));
+
+    final childRoute = RouteMock();
+    final childParallel = ParallelRouteMock();
+    when(() => childParallel.uri).thenReturn(Uri.parse('/child'));
+    when(() => childParallel.parent).thenReturn('/');
+    final childPage = ModularPage(
+        route: childParallel, args: ModularArguments.empty(), flags: ModularFlags());
+    when(() => childRoute.didPop(null)).thenReturn(true);
+    when(() => childRoute.settings).thenReturn(childPage);
+    when(() => childRoute.isFirst).thenReturn(false);
+
+    when(() => reportPopMock.call(childParallel)).thenReturn(const Success(unit));
+
+    final arguments = ModularArguments.empty();
+    final getArgsMock = GetArgumentsMock();
+    final setArgsMock = SetArgumentsMock();
+    when(() => parser.getArguments).thenReturn(getArgsMock);
+    when(() => parser.setArguments).thenReturn(setArgsMock);
+
+    when(getArgsMock.call).thenReturn(Success(arguments));
+    when(() => setArgsMock.call(any())).thenReturn(const Success(unit));
+
+    delegate.currentConfiguration = ModularBook(routes: [parallel, childParallel]);
+    expect(delegate.currentConfiguration?.routes.length, 2);
+    delegate.onPopPage(route, null);
+    expect(delegate.currentConfiguration?.routes.length, 0);
+    expect(delegate.navigateHistory, delegate.currentConfiguration?.routes);
+  });
   test('pushNamed with forRoot', () async {
     final route1 = ParallelRouteMock();
     final route2 = ParallelRouteMock();

--- a/modular_core/lib/src/tracker.dart
+++ b/modular_core/lib/src/tracker.dart
@@ -162,7 +162,7 @@ class _Tracker implements Tracker {
         continue;
       }
 
-      moduleTags.remove(tag);
+      moduleTags.removeWhere((element) => element.startsWith(tag));
       if (tag.characters.last == '/') {
         moduleTags.remove('$tag/'.replaceAll('//', ''));
       }


### PR DESCRIPTION
# Description

This PR is intended to fix issue #960. Additional checks were added when popping from the navigation stack to prevent leaving orphaned navigation routes or modules. These changes ensure all child routes are removed from navigation history and that the enclosing module will be disposed if no other routes from that module exist on the stack.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

Fixes #960 
