### PR TITLE
Fix the logical flux control on WebUrlService Class - FLutterWeb

### DIFF
--- a/flutter_modular/lib/src/infra/services/url_service/html_url_service.dart
+++ b/flutter_modular/lib/src/infra/services/url_service/html_url_service.dart
@@ -12,11 +12,12 @@ class WebUrlService extends UrlService {
   String? getPath() {
     final href = window.location.href;
 
-    if (urlStrategy is HashUrlStrategy) {
-      if (href.endsWith(Modular.initialRoute)) {
-        return Modular.initialRoute;
-      } else if (href.contains('#')) {
+  if (urlStrategy is HashUrlStrategy) {
+      if (href.contains('#')) {
         return href.split('#').last;
+      } else if (href.endsWith(Modular.initialRoute)) {
+        return Modular.initialRoute;
+        
       }
     }
 


### PR DESCRIPTION
# Description

This bugs happens with the initalRoute is "/"

The bug was on FlutterWeb when you click on an link that contains a path after '#'  or paste it on browser and the link ends with "/" and your initialRoute/baseUrl/homeUrl  is "/" then the window reloads and redirects you to the home screen. 
The reason of this bug is that on WebUrlService the logical check for UrlStrategy first checks if the href ends with initialRoute, and because the link ends with "/" and the initalRoute is "/"  the condition is satisfied and  the user is redirected to the homeScreen and not to the desired destination.
To fix this, this PR only inverts the logic of the UrlStrategy check. The logic on this PR first checks if the href contains '#' than if it ends with initialRoute.

## Checklist


- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [X] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues
i if this PR can solve the bug related on issue  https://github.com/Flutterando/modular/issues/834

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
