### PR TITLE
fix: Solve the problem that `selectRoute` cannot recover after finding a wildcard route during the initial attempt.

### DIFF
--- a/flutter_modular/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_modular/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,7 +13,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
-  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/src/domain/errors/errors.dart';
-import 'package:modular_core/modular_core.dart';
 import 'package:result_dart/result_dart.dart';
 
 import '../../../flutter_modular.dart';

--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -115,7 +115,7 @@ class ModularRouteInformationParser
     final params = RouteParmsDTO(url: path, arguments: arguments);
 
     final fistTrying = getRoute.call(params).flatMap<ModularRoute>((success) {
-      if (success.name == '/**') {
+      if (success.name.endsWith('/**')) {
         return const Failure(RouteNotFoundException(
             'Wildcard is not available for the first time'));
       }

--- a/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
@@ -19,7 +19,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:modular_core/modular_core.dart';
 import 'package:result_dart/result_dart.dart';
 
-import '../../mocks/mocks.dart';
 import '../modular_base_test.dart';
 
 class GetRouteMock extends Mock implements GetRoute {}
@@ -68,6 +67,7 @@ void main() {
     when(() => routeMock.uri).thenReturn(Uri.parse('/'));
     when(() => routeMock.parent).thenReturn('');
     when(() => routeMock.schema).thenReturn('');
+    when(() => routeMock.name).thenReturn('/');
     when(() => getRoute.call(any()))
         .thenAnswer((_) async => Success(routeMock));
     when(() => getArguments.call())
@@ -87,6 +87,7 @@ void main() {
     when(() => routeMock.uri).thenReturn(Uri.parse('/test'));
     when(() => routeMock.parent).thenReturn('/');
     when(() => routeMock.schema).thenReturn('/');
+    when(() => routeMock.name).thenReturn('/test');
     when(() => routeMock.middlewares).thenReturn([Guard()]);
     when(() => routeMock.copyWith(schema: any(named: 'schema')))
         .thenReturn(routeMock);
@@ -95,6 +96,7 @@ void main() {
     when(() => routeParent.uri).thenReturn(Uri.parse('/'));
     when(() => routeParent.parent).thenReturn('');
     when(() => routeParent.schema).thenReturn('');
+    when(() => routeParent.name).thenReturn('/');
     when(() => routeParent.middlewares).thenReturn([Guard()]);
     when(() => routeParent.copyWith(schema: any(named: 'schema')))
         .thenReturn(routeParent);
@@ -125,6 +127,7 @@ void main() {
     when(() => routeMock.uri).thenReturn(Uri.parse('/test'));
     when(() => routeMock.parent).thenReturn('/');
     when(() => routeMock.schema).thenReturn('/');
+    when(() => routeMock.name).thenReturn('/test');
     when(() => routeMock.middlewares).thenReturn([Guard()]);
     when(() => routeMock.copyWith(schema: any(named: 'schema')))
         .thenReturn(routeMock);
@@ -133,6 +136,7 @@ void main() {
     when(() => routeParent.uri).thenReturn(Uri.parse('/'));
     when(() => routeParent.parent).thenReturn('');
     when(() => routeParent.schema).thenReturn('');
+    when(() => routeParent.name).thenReturn('/');
     when(() => routeParent.middlewares).thenReturn([Guard()]);
     when(() => routeParent.copyWith(schema: any(named: 'schema')))
         .thenReturn(routeParent);
@@ -190,6 +194,7 @@ void main() {
     final routeMock = ParallelRouteMock();
     when(() => routeMock.uri).thenReturn(Uri.parse('/'));
     when(() => routeMock.parent).thenReturn('');
+    when(() => routeMock.name).thenReturn('/');
 
     when(() => reportPush(routeMock)).thenReturn(const Success(unit));
 
@@ -217,6 +222,7 @@ void main() {
         .thenReturn(Success(ModularArguments.empty()));
     when(() => routeMock.middlewares).thenReturn([Guard(false)]);
     when(() => routeMock.uri).thenReturn(Uri.parse('/'));
+    when(() => routeMock.name).thenReturn('/');
 
     expect(
         () =>
@@ -233,6 +239,7 @@ void main() {
         .thenReturn(Success(ModularArguments.empty()));
     when(() => routeMock.middlewares).thenReturn([MiddlewareNull()]);
     when(() => routeMock.uri).thenReturn(Uri.parse('/'));
+    when(() => routeMock.name).thenReturn('/');
 
     expect(
         () =>
@@ -253,24 +260,59 @@ void main() {
         .thenReturn(Success(ModularArguments.empty()));
     when(() => routeMock.middlewares).thenReturn([]);
     when(() => routeMock.uri).thenReturn(Uri.parse('/'));
+    when(() => routeMock.name).thenReturn('/');
     when(() => routeMock.parent).thenReturn('');
     when(() => routeMock.copyWith(popCallback: any(named: 'popCallback')))
         .thenReturn(routeMock);
     expect(parser.selectBook('/', popCallback: (r) {}), completes);
   });
 
-  test('selectRoute with wildcard', () {
+  test('selectRoute with wildcard', () async {
     final routeMock = ParallelRouteMock();
-    when(() => routeMock.uri).thenReturn(Uri.parse('/'));
-    when(() => routeMock.parent).thenReturn('');
-    when(() => routeMock.schema).thenReturn('');
-    when(() => routeMock.middlewares).thenReturn([]);
+    when(() => routeMock.uri).thenReturn(Uri.parse('/parent/test'));
+    when(() => routeMock.parent).thenReturn('/parent');
+    when(() => routeMock.schema).thenReturn('/parent');
+    when(() => routeMock.name).thenReturn('/test');
+    when(() => routeMock.middlewares).thenReturn([Guard()]);
+    when(() => routeMock.copyWith(schema: any(named: 'schema')))
+        .thenReturn(routeMock);
+
+    final routeMock1 = ParallelRouteMock();
+    when(() => routeMock1.uri).thenReturn(Uri.parse('/**'));
+    when(() => routeMock1.parent).thenReturn('');
+    when(() => routeMock1.schema).thenReturn('');
+    when(() => routeMock1.name).thenReturn('/**');
+    when(() => routeMock1.middlewares).thenReturn([Guard()]);
+    when(() => routeMock1.copyWith(schema: any(named: 'schema')))
+        .thenReturn(routeMock);
+
+    final routeParent = ParallelRouteMock();
+    when(() => routeParent.uri).thenReturn(Uri.parse('/parent'));
+    when(() => routeParent.parent).thenReturn('');
+    when(() => routeParent.schema).thenReturn('');
+    when(() => routeParent.name).thenReturn('/parent');
+    when(() => routeParent.middlewares).thenReturn([Guard()]);
+    when(() => routeParent.copyWith(schema: any(named: 'schema')))
+        .thenReturn(routeParent);
 
     when(() => reportPush(routeMock)).thenReturn(const Success(unit));
+    when(() => reportPush(routeMock1)).thenReturn(const Success(unit));
+    when(() => reportPush(routeParent)).thenReturn(const Success(unit));
 
-    final moduleMock = ModuleMock();
-    when(() => routeMock.children)
-        .thenReturn([ModuleRoute('/test', module: moduleMock)]);
+    when(() => getRoute.call(const RouteParmsDTO(url: '/parent/test')))
+        .thenAnswer((_) async => Success(routeMock1));
+    when(() => getRoute.call(const RouteParmsDTO(url: '/parent/test/')))
+        .thenAnswer((_) async => Success(routeMock));
+    when(() => getRoute.call(const RouteParmsDTO(url: '/parent')))
+        .thenAnswer((_) async => Success(routeParent));
+    when(() => getArguments.call())
+        .thenReturn(Success(ModularArguments.empty()));
+
+    when(() => setArguments.call(any())).thenReturn(const Success(unit));
+
+    final book = await parser.selectBook('/parent/test');
+    expect(book.uri.toString(), '/parent/test');
+    expect(book.chapters().first.name, '/parent');
   });
 }
 

--- a/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
@@ -19,6 +19,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:modular_core/modular_core.dart';
 import 'package:result_dart/result_dart.dart';
 
+import '../../mocks/mocks.dart';
 import '../modular_base_test.dart';
 
 class GetRouteMock extends Mock implements GetRoute {}
@@ -256,6 +257,20 @@ void main() {
     when(() => routeMock.copyWith(popCallback: any(named: 'popCallback')))
         .thenReturn(routeMock);
     expect(parser.selectBook('/', popCallback: (r) {}), completes);
+  });
+
+  test('selectRoute with wildcard', () {
+    final routeMock = ParallelRouteMock();
+    when(() => routeMock.uri).thenReturn(Uri.parse('/'));
+    when(() => routeMock.parent).thenReturn('');
+    when(() => routeMock.schema).thenReturn('');
+    when(() => routeMock.middlewares).thenReturn([]);
+
+    when(() => reportPush(routeMock)).thenReturn(const Success(unit));
+
+    final moduleMock = ModuleMock();
+    when(() => routeMock.children)
+        .thenReturn([ModuleRoute('/test', module: moduleMock)]);
   });
 }
 


### PR DESCRIPTION
# Description

<!-- Provide a description of what this PR is doing. 
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs have been
changed. -->
There are routes: `/**`, `/test/`, and if I want to find `/test/` using `Modular.to.pushNamed('/test')`, `/**` will be matched, that is unexpected. So in this PR, when finding wildcard route at the first time in the `selectRoute`, it will also do the recovery.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
