### PR TITLE
fix: webassembly

### DIFF
--- a/flutter_modular/lib/src/flutter_modular_module.dart
+++ b/flutter_modular/lib/src/flutter_modular_module.dart
@@ -59,22 +59,9 @@ final injector = AutoInjector(
     i.add<ReplaceInstance>(ReplaceInstanceImpl.new);
     //presenter
     i.addInstance(GlobalKey<NavigatorState>());
-    i.addSingleton<ModularRouteInformationParser>(() {
-      return ModularRouteInformationParser(
-        getArguments: i(),
-        getRoute: i(),
-        reportPush: i(),
-        setArguments: i(),
-        urlService: i(),
-      );
-    });
-    i.addSingleton<ModularRouterDelegate>(() {
-      return ModularRouterDelegate(
-        navigatorKey: i(),
-        parser: i(),
-        reportPop: i(),
-      );
-    });
+    i.addSingleton<ModularRouteInformationParser>(
+        ModularRouteInformationParser.new);
+    i.addSingleton<ModularRouterDelegate>(ModularRouterDelegate.new);
     i.add<IModularNavigator>(() => i<ModularRouterDelegate>());
     i.addLazySingleton<IModularBase>(ModularBase.new);
 

--- a/flutter_modular/lib/src/flutter_modular_module.dart
+++ b/flutter_modular/lib/src/flutter_modular_module.dart
@@ -59,10 +59,22 @@ final injector = AutoInjector(
     i.add<ReplaceInstance>(ReplaceInstanceImpl.new);
     //presenter
     i.addInstance(GlobalKey<NavigatorState>());
-    i.addSingleton<ModularRouteInformationParser>(
-      ModularRouteInformationParser.new,
-    );
-    i.addSingleton<ModularRouterDelegate>(ModularRouterDelegate.new);
+    i.addSingleton<ModularRouteInformationParser>(() {
+      return ModularRouteInformationParser(
+        getArguments: i(),
+        getRoute: i(),
+        reportPush: i(),
+        setArguments: i(),
+        urlService: i(),
+      );
+    });
+    i.addSingleton<ModularRouterDelegate>(() {
+      return ModularRouterDelegate(
+        navigatorKey: i(),
+        parser: i(),
+        reportPop: i(),
+      );
+    });
     i.add<IModularNavigator>(() => i<ModularRouterDelegate>());
     i.addLazySingleton<IModularBase>(ModularBase.new);
 

--- a/flutter_modular/lib/src/presenter/modular_base.dart
+++ b/flutter_modular/lib/src/presenter/modular_base.dart
@@ -116,20 +116,20 @@ class ModularBase implements IModularBase {
   @override
   String get initialRoutePath => _initialRoutePath;
 
-  ModularBase({
-    required this.routeInformationParser,
-    required this.routerDelegate,
-    required this.disposeBind,
-    required this.getArguments,
-    required this.finishModule,
-    required this.getBind,
-    required this.startModule,
-    required this.navigator,
-    required this.setArgumentsUsecase,
-    required this.bindModuleUsecase,
-    required this.unbindModuleUsecase,
-    required this.replaceInstanceUsecase,
-  });
+  ModularBase(
+    this.routeInformationParser,
+    this.routerDelegate,
+    this.disposeBind,
+    this.getArguments,
+    this.finishModule,
+    this.getBind,
+    this.startModule,
+    this.navigator,
+    this.setArgumentsUsecase,
+    this.bindModuleUsecase,
+    this.unbindModuleUsecase,
+    this.replaceInstanceUsecase,
+  );
 
   @override
   bool dispose<B extends Object>({String? key}) =>

--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -22,13 +22,13 @@ class ModularRouteInformationParser
   final ReportPush reportPush;
   final UrlService urlService;
 
-  ModularRouteInformationParser({
-    required this.getRoute,
-    required this.getArguments,
-    required this.setArguments,
-    required this.reportPush,
-    required this.urlService,
-  });
+  ModularRouteInformationParser(
+    this.getRoute,
+    this.getArguments,
+    this.setArguments,
+    this.reportPush,
+    this.urlService,
+  );
 
   @override
   Future<ModularBook> parseRouteInformation(

--- a/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
@@ -23,10 +23,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularBook>
   final ReportPop reportPop;
   List<NavigatorObserver> observers = [];
 
-  ModularRouterDelegate(
-      {required this.parser,
-      required this.navigatorKey,
-      required this.reportPop});
+  ModularRouterDelegate(this.parser, this.navigatorKey, this.reportPop);
 
   @override
   ModularBook? currentConfiguration;

--- a/flutter_modular/test/src/presenter/modular_base_test.dart
+++ b/flutter_modular/test/src/presenter/modular_base_test.dart
@@ -84,18 +84,18 @@ void main() {
 
   setUp(() {
     modularBase = ModularBase(
-      disposeBind: disposeBind,
-      finishModule: finishModule,
-      getArguments: getArguments,
-      getBind: getBind,
-      navigator: modularNavigator,
-      startModule: startModule,
-      routeInformationParser: routeInformationParser,
-      routerDelegate: routerDelegate,
-      setArgumentsUsecase: setArguments,
-      bindModuleUsecase: bindModule,
-      replaceInstanceUsecase: replaceInstance,
-      unbindModuleUsecase: unbindModule,
+      routeInformationParser,
+      routerDelegate,
+      disposeBind,
+      getArguments,
+      finishModule,
+      getBind,
+      startModule,
+      modularNavigator,
+      setArguments,
+      bindModule,
+      unbindModule,
+      replaceInstance,
     );
 
     reset(disposeBind);

--- a/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
@@ -48,11 +48,11 @@ void main() {
     reportPush = ReportPushMock();
     urlService = UrlServiceMock();
     parser = ModularRouteInformationParser(
-      getArguments: getArguments,
-      getRoute: getRoute,
-      setArguments: setArguments,
-      reportPush: reportPush,
-      urlService: urlService,
+      getRoute,
+      getArguments,
+      setArguments,
+      reportPush,
+      urlService,
     );
   });
 

--- a/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
@@ -54,11 +54,7 @@ void main() {
     reportPopMock = ReportPopMock();
     when(() => key.currentState).thenReturn(navigatorState);
     parser = ModularRouteInformationParserMock();
-    delegate = ModularRouterDelegate(
-      parser: parser,
-      navigatorKey: key,
-      reportPop: reportPopMock,
-    );
+    delegate = ModularRouterDelegate(parser, key, reportPopMock);
   });
 
   test('setObserver', () {


### PR DESCRIPTION
# Problem
When you run an empty project in WASM using flutter_modular it breaks.

# Solution
I believe this issue will be resolved in the Flutter engine itself in the future. It’s likely specific to WASM compilation, as it doesn’t occur on other platforms. Looks like some named params are not working well in WASM, so I recommend to use constructors with positional params of named params.

The injections causing the error in an empty project are internal to flutter_modular. I managed to resolve it by changing the constructors params from positional to named (see the changed files).

# For developers
If you want to use named params and you are receiving this error you need to register your dependency like that _(only for the dependencies that are returning error in the browser console)_:

🚫 Before (does not work on WASM)
```dart
    i.addSingleton<ModularRouteInformationParser>(ModularRouteInformationParser.new);
```

✅ After (Works on WASM)
```dart
    i.addSingleton<ModularRouteInformationParser>(() {
      return ModularRouteInformationParser(
        getArguments: i(),
        getRoute: i(),
        reportPush: i(),
        setArguments: i(),
        urlService: i(),
      );
    });
``` 

When we have it fixed (in Flutter side or in the auto_injector package) this workaround will not be needed anymore.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->
- Closes #975 
- Closes https://github.com/Flutterando/auto_injector/issues/23

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
