### PR TITLE
fix: improve parity between shelf and flutter

### DIFF
--- a/flutter_modular/lib/src/infra/services/url_service/html_url_service.dart
+++ b/flutter_modular/lib/src/infra/services/url_service/html_url_service.dart
@@ -12,11 +12,12 @@ class WebUrlService extends UrlService {
   String? getPath() {
     final href = window.location.href;
 
-    if (urlStrategy is HashUrlStrategy) {
-      if (href.endsWith(Modular.initialRoute)) {
-        return Modular.initialRoute;
-      } else if (href.contains('#')) {
+  if (urlStrategy is HashUrlStrategy) {
+      if (href.contains('#')) {
         return href.split('#').last;
+      } else if (href.endsWith(Modular.initialRoute)) {
+        return Modular.initialRoute;
+        
       }
     }
 

--- a/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_router_delegate.dart
@@ -117,6 +117,7 @@ class ModularRouterDelegate extends RouterDelegate<ModularBook>
     final parallel = page.route;
     parallel.popCallback?.call(result);
     currentConfiguration?.routes.remove(parallel);
+    currentConfiguration?.routes.removeWhere((element) => element.parent == parallel.uri.toString());
     if (currentConfiguration?.routes.indexWhere(
             (element) => element.uri.toString() == parallel.uri.toString()) ==
         -1) {

--- a/flutter_modular/pubspec.yaml
+++ b/flutter_modular/pubspec.yaml
@@ -21,5 +21,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  modular_core:
+    git:
+      url: https://github.com/necodeIT/modular.git
+      path: modular_core
+
 
 flutter:

--- a/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_router_delegate_test.dart
@@ -159,7 +159,45 @@ void main() {
     expect(delegate.currentConfiguration?.routes.length, 0);
     expect(delegate.navigateHistory, delegate.currentConfiguration?.routes);
   });
+  test('onPopPage with parent/child route', () {
+    final route = RouteMock();
+    final parallel = ParallelRouteMock();
+    when(() => parallel.uri).thenReturn(Uri.parse('/'));
+    final page = ModularPage(
+        route: parallel, args: ModularArguments.empty(), flags: ModularFlags());
+    when(() => route.didPop(null)).thenReturn(true);
+    when(() => route.settings).thenReturn(page);
+    when(() => route.isFirst).thenReturn(false);
 
+    when(() => reportPopMock.call(parallel)).thenReturn(const Success(unit));
+
+    final childRoute = RouteMock();
+    final childParallel = ParallelRouteMock();
+    when(() => childParallel.uri).thenReturn(Uri.parse('/child'));
+    when(() => childParallel.parent).thenReturn('/');
+    final childPage = ModularPage(
+        route: childParallel, args: ModularArguments.empty(), flags: ModularFlags());
+    when(() => childRoute.didPop(null)).thenReturn(true);
+    when(() => childRoute.settings).thenReturn(childPage);
+    when(() => childRoute.isFirst).thenReturn(false);
+
+    when(() => reportPopMock.call(childParallel)).thenReturn(const Success(unit));
+
+    final arguments = ModularArguments.empty();
+    final getArgsMock = GetArgumentsMock();
+    final setArgsMock = SetArgumentsMock();
+    when(() => parser.getArguments).thenReturn(getArgsMock);
+    when(() => parser.setArguments).thenReturn(setArgsMock);
+
+    when(getArgsMock.call).thenReturn(Success(arguments));
+    when(() => setArgsMock.call(any())).thenReturn(const Success(unit));
+
+    delegate.currentConfiguration = ModularBook(routes: [parallel, childParallel]);
+    expect(delegate.currentConfiguration?.routes.length, 2);
+    delegate.onPopPage(route, null);
+    expect(delegate.currentConfiguration?.routes.length, 0);
+    expect(delegate.navigateHistory, delegate.currentConfiguration?.routes);
+  });
   test('pushNamed with forRoot', () async {
     final route1 = ParallelRouteMock();
     final route2 = ParallelRouteMock();

--- a/modular_core/lib/src/route/route.dart
+++ b/modular_core/lib/src/route/route.dart
@@ -96,4 +96,9 @@ class ModularKey {
   }) {
     return ModularKey(schema: schema ?? this.schema, name: name ?? this.name);
   }
+
+  @override
+  String toString() {
+    return 'ModularKey(schema: $schema, name: $name)';
+  }
 }

--- a/modular_core/lib/src/tracker.dart
+++ b/modular_core/lib/src/tracker.dart
@@ -162,7 +162,7 @@ class _Tracker implements Tracker {
         continue;
       }
 
-      moduleTags.remove(tag);
+      moduleTags.removeWhere((element) => element.startsWith(tag));
       if (tag.characters.last == '/') {
         moduleTags.remove('$tag/'.replaceAll('//', ''));
       }

--- a/shelf_modular/.vscode/settings.json
+++ b/shelf_modular/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "shelf_modular"
+    ]
+}

--- a/shelf_modular/lib/shelf_modular.dart
+++ b/shelf_modular/lib/shelf_modular.dart
@@ -12,7 +12,8 @@ export 'package:modular_core/modular_core.dart'
         BindConfig,
         Injector,
         AutoInjectorException,
-        ModularArguments;
+        ModularArguments,
+        RouteManager;
 
 export 'src/presenter/extensions/route_manage_extension.dart';
 export 'src/presenter/middlewares/middlewares.dart';

--- a/shelf_modular/lib/shelf_modular.dart
+++ b/shelf_modular/lib/shelf_modular.dart
@@ -13,7 +13,8 @@ export 'package:modular_core/modular_core.dart'
         Injector,
         AutoInjectorException,
         ModularArguments,
-        RouteManager;
+        RouteManager,
+        setPrintResolver;
 
 export 'src/presenter/extensions/route_manage_extension.dart';
 export 'src/presenter/middlewares/middlewares.dart';

--- a/shelf_modular/lib/src/presenter/extensions/route_manage_extension.dart
+++ b/shelf_modular/lib/src/presenter/extensions/route_manage_extension.dart
@@ -45,9 +45,10 @@ extension RouteManagerExt on RouteManager {
 
   void resource(
     Resource resource, {
+    String name = '/',
     List<ModularMiddleware> middlewares = const [],
   }) {
-    add(Route.resource(resource, middlewares: middlewares));
+    add(Route.resource(name, resource: resource, middlewares: middlewares));
   }
 
   void module(

--- a/shelf_modular/lib/src/presenter/extensions/route_manage_extension.dart
+++ b/shelf_modular/lib/src/presenter/extensions/route_manage_extension.dart
@@ -1,5 +1,3 @@
-import 'package:modular_core/modular_core.dart';
-
 import '../../../shelf_modular.dart';
 
 extension RouteManagerExt on RouteManager {

--- a/shelf_modular/lib/src/presenter/models/route.dart
+++ b/shelf_modular/lib/src/presenter/models/route.dart
@@ -82,7 +82,8 @@ class Route extends ModularRoute {
   }
 
   factory Route.resource(
-    Resource resource, {
+    String name, {
+    required Resource resource,
     List<ModularMiddleware> middlewares = const [],
   }) {
     final manager = RouteManager();
@@ -90,7 +91,7 @@ class Route extends ModularRoute {
     resource.routes(manager);
 
     return Route._(
-      '/',
+      name,
       // ignore: invalid_use_of_visible_for_testing_member
       children: manager.allRoutes,
       middlewares: middlewares,

--- a/shelf_modular/lib/src/presenter/models/route.dart
+++ b/shelf_modular/lib/src/presenter/models/route.dart
@@ -85,9 +85,14 @@ class Route extends ModularRoute {
     Resource resource, {
     List<ModularMiddleware> middlewares = const [],
   }) {
+    final manager = RouteManager();
+
+    resource.routes(manager);
+
     return Route._(
       '/',
-      children: resource.routes,
+      // ignore: invalid_use_of_visible_for_testing_member
+      children: manager.allRoutes,
       middlewares: middlewares,
     );
   }

--- a/shelf_modular/lib/src/presenter/modular_base.dart
+++ b/shelf_modular/lib/src/presenter/modular_base.dart
@@ -197,6 +197,9 @@ class ModularBase implements IModularBase {
     if (!_isMultipart(request)) {
       try {
         final data = await request.readAsString();
+
+        if (data.isEmpty) return {};
+
         return jsonDecode(data);
       } on FormatException catch (e) {
         print(e);

--- a/shelf_modular/lib/src/presenter/modular_base.dart
+++ b/shelf_modular/lib/src/presenter/modular_base.dart
@@ -123,7 +123,9 @@ class ModularBase implements IModularBase {
   @visibleForTesting
   FutureOr<Response> handler(Request request) async {
     try {
-      final data = await tryJsonDecode(request);
+      final body = await request.readAsString();
+
+      final data = await tryJsonDecode(request.change(body: body));
       final params = RouteParmsDTO(
         url: '/${request.url.toString()}',
         schema: request.method,
@@ -131,7 +133,7 @@ class ModularBase implements IModularBase {
       );
       return getRoute //
           .call(params)
-          .map((route) => _routeSuccess(route, request))
+          .map((route) => _routeSuccess(route, request.change(body: body)))
           .mapError(_routeError)
           .fold(identity, identity);
     } on Exception catch (e, s) {
@@ -142,7 +144,7 @@ class ModularBase implements IModularBase {
       } else {
         print(e.toString());
         print('STACK TRACE \n $s');
-        return Response.internalServerError(body: '${e.toString()}/n$s');
+        return Response.internalServerError();
       }
     }
   }

--- a/shelf_modular/lib/src/presenter/resources/resource.dart
+++ b/shelf_modular/lib/src/presenter/resources/resource.dart
@@ -1,5 +1,5 @@
 import 'package:shelf_modular/shelf_modular.dart';
 
 abstract class Resource {
-  List<Route> get routes;
+  void routes(RouteManager r);
 }

--- a/shelf_modular/lib/src/shelf_modular_module.dart
+++ b/shelf_modular/lib/src/shelf_modular_module.dart
@@ -26,7 +26,7 @@ final _innerInjector = AutoInjector(
 final injector = AutoInjector(
   tag: 'ModularCore',
   on: (i) {
-    i.add<Tracker>(Tracker.new);
+    i.addLazySingleton<Tracker>(Tracker.new);
     i.addInstance<AutoInjector>(_innerInjector);
     //infra
     i.add<BindService>(BindServiceImpl.new);

--- a/shelf_modular/pubspec.yaml
+++ b/shelf_modular/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   shelf: ">=1.3.0 <2.0.0"
   meta: ">=1.3.0 <2.0.0"
-  modular_core: ">=3.0.0-rc.2 <4.0.0"
+  modular_core: ^3.3.3
   mime: ">=1.0.2 <2.0.0"
   http_parser: ">=4.0.1 <5.0.0"
   web_socket_channel: ">=2.2.0 <3.0.0"

--- a/shelf_modular/pubspec.yaml
+++ b/shelf_modular/pubspec.yaml
@@ -16,6 +16,12 @@ dependencies:
   shelf_web_socket: ">=1.0.1 <2.0.0"
   result_dart: ">=1.0.5 <2.0.0"
 
+dependency_overrides:
+  modular_core:
+    git:
+      url: https://github.com/necodeIT/modular.git
+      path: modular_core
+
 dev_dependencies:
   mocktail: ^0.3.0
   flutterando_analysis: ^0.0.2

--- a/shelf_modular/test/src/presenter/extensions/route_manage_extension_test.dart
+++ b/shelf_modular/test/src/presenter/extensions/route_manage_extension_test.dart
@@ -21,7 +21,7 @@ void main() {
 
 class CustomResource extends Resource {
   @override
-  List<Route> get routes => [];
+  void routes(RouteManager r) {}
 }
 
 class CustomModule extends Module {}


### PR DESCRIPTION
# Description

This PR aims to make modules written with `modular_core` to work in shelf and flutter.
Also has #963 merged.

- [ ] Remove dependency overrides in pubspec.yaml review passes

### Routing Mechanism Improvements:
* [`shelf_modular/lib/src/presenter/extensions/route_manage_extension.dart`](diffhunk://#diff-7df4b9920dea966a6d1c38d22b5becb2514dcdc28ce88183965b2e57a0a1a697R48-R51): Added a `name` parameter to the `resource` method to allow named routes.
* [`shelf_modular/lib/src/presenter/models/route.dart`](diffhunk://#diff-dc54b8d5ad9e2e4006a5e5e91725db0460bce46b2fde1960821481fc91ae7195L85-R96): Updated the `Route.resource` factory to include a `name` parameter and utilize the `RouteManager` for managing child routes.
* [`shelf_modular/lib/src/presenter/resources/resource.dart`](diffhunk://#diff-b98d8bf67bdd48c2d76b8e3f9b915267400ea6b494a243ec1dfcf0d7850016feL4-R4): Changed the `routes` method in the `Resource` class to accept a `RouteManager` parameter instead of returning a list of routes.

### Class Enhancements:
* [`modular_core/lib/src/route/route.dart`](diffhunk://#diff-f5a40339330b28e93a7067746deec0c101668771736771da619f98d7c130ff86R99-R103): Added a `toString` method to the `ModularKey` class for better debugging and logging.
* [`shelf_modular/lib/src/presenter/modular_base.dart`](diffhunk://#diff-ddc592d9390336b3afb9d5bfab935c4334ab8a2c9ed08e545d1770b1ac3d8515R200-R202): Added a check to return an empty map if the request data is empty in the `ModularBase` class.

These changes collectively enhance the routing capabilities, ensure compatibility with the latest dependencies, and improve the overall code quality and maintainability.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

`shelf_modular` now uses the same builder methods for binds instead of a getter.

- [x ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

#963
#968

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
