### PR TITLE
fix: update Deep Link query parameters and add tests

### DIFF
--- a/flutter_modular/CHANGELOG.md
+++ b/flutter_modular/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [6.3.4] - 2025-05-02
+- Fix Deep Link query parameters
+
 ## [6.3.3] - 2024-04-08
 - Fix Deep Link
 

--- a/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart
@@ -47,7 +47,10 @@ class ModularRouteInformationParser
       path = location;
     }
 
-    return selectBook(path);
+    return selectBook(
+      path,
+      arguments: routeInformation.uri.queryParameters,
+    );
   }
 
   @override

--- a/flutter_modular/pubspec.yaml
+++ b/flutter_modular/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_modular
 description: Smart project structure with dependency injection and route management
-version: 6.3.3
+version: 6.3.4
 homepage: https://github.com/Flutterando/modular
 
 environment:

--- a/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart
@@ -81,6 +81,27 @@ void main() {
     expect(book.chapters().first.name, '/');
   });
 
+  test('parseRouteInformation calls selectBook with correct arguments',
+      () async {
+    final routeMock = ParallelRouteMock();
+    final params = {'param': 'value'};
+    final uri = Uri.parse('/test');
+    when(() => routeMock.uri).thenReturn(uri);
+    when(() => routeMock.parent).thenReturn('');
+    when(() => routeMock.middlewares).thenReturn([]);
+    when(() => getRoute.call(any()))
+        .thenAnswer((_) async => Success(routeMock));
+    when(() => getArguments.call())
+        .thenReturn(Success(ModularArguments(uri: uri, data: params)));
+    when(() => reportPush(routeMock)).thenReturn(const Success(unit));
+
+    const routeInformation = RouteInformation(location: '/test?param=value');
+    final book = await parser.parseRouteInformation(routeInformation);
+
+    expect(book.uri.toString(), '/test');
+    expect(parser.getArguments.call().getOrNull()?.data, params);
+  });
+
   test('selectBook with parents', () async {
     final routeMock = ParallelRouteMock();
     when(() => routeMock.uri).thenReturn(Uri.parse('/test'));


### PR DESCRIPTION
# Description


This pull request introduces a bug fix for handling query parameters in deep links within the `flutter_modular` package. It updates the version to `6.3.4` and includes corresponding changes in the implementation and tests to ensure correctness.

### Bug Fix: Deep Link Query Parameters
* [`flutter_modular/lib/src/presenter/navigation/modular_route_information_parser.dart`](diffhunk://#diff-ac4787b260133f94853d99318ec8f2fcb6f31f59ab6d2e7ba9dc73e65141cb21L50-R53): Updated the `parseRouteInformation` method in `ModularRouteInformationParser` to pass `routeInformation.uri.queryParameters` as arguments to the `selectBook` method.

### Documentation Update
* [`flutter_modular/CHANGELOG.md`](diffhunk://#diff-3dd59d74f494d7c85281dd99da0caab9b629d425410c186ea18e6ac6e4eb6567R1-R3): Added a new entry for version `6.3.4`, documenting the fix for deep link query parameters.

### Version Update
* [`flutter_modular/pubspec.yaml`](diffhunk://#diff-2ce930361718de4f7e3b81165ef1b37e700b02ca883d6ca5be9bc2d2ea86416bL3-R3): Bumped the package version from `6.3.3` to `6.3.4`.

### Test Coverage
* [`flutter_modular/test/src/presenter/navigation/modular_route_information_parser_test.dart`](diffhunk://#diff-783e127e98d125505282aa30e48bfafec405a92b1e3283cc3e2f1d7745d07a22R84-R104): Added a new test to verify that `parseRouteInformation` correctly calls `selectBook` with the expected arguments, including query parameters.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
