### PR TITLE
Fixes #1028

### DIFF
--- a/flutter_modular/lib/src/presenter/modular_base.dart
+++ b/flutter_modular/lib/src/presenter/modular_base.dart
@@ -174,7 +174,7 @@ class ModularBase implements IModularBase {
   final flags = ModularFlags();
 
   @override
-  final String initialRoute = '/';
+  String get initialRoute => _initialRoutePath;
 
   @override
   void setInitialRoute(String value) {
@@ -201,8 +201,7 @@ class ModularBase implements IModularBase {
     routerDelegate: routerDelegate,
     routeInformationParser: routeInformationParser,
     routeInformationProvider: PlatformRouteInformationProvider(
-      // ignore: deprecated_member_use
-      initialRouteInformation: const RouteInformation(location: '/'),
+      initialRouteInformation: const RouteInformation(uri: Uri.parse(initialRoute)),
     ),
     backButtonDispatcher: RootBackButtonDispatcher(),
   );


### PR DESCRIPTION
Fixing setInitialRoute bug

# Description

Fixing setInitialRoute bug that makes the initialRoute never change.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

[<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->](https://github.com/Flutterando/modular/issues/1028)

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
