### PR TITLE
feat: Added routeBuilder to CustomTransition

### DIFF
--- a/flutter_modular/lib/src/presenter/models/route.dart
+++ b/flutter_modular/lib/src/presenter/models/route.dart
@@ -211,14 +211,16 @@ class CustomTransition {
     Animation<double>,
     Animation<double>,
   )? pageBuilder;
+  final RouteBuilder? routeBuilder;
   final Duration transitionDuration;
   final Duration reverseTransitionDuration;
   final bool opaque;
 
   CustomTransition(
       {required this.transitionBuilder,
+      this.pageBuilder,
+      this.routeBuilder,
       this.transitionDuration = const Duration(milliseconds: 300),
       this.reverseTransitionDuration = const Duration(milliseconds: 300),
-      this.opaque = true,
-      this.pageBuilder});
+      this.opaque = true});
 }

--- a/flutter_modular/lib/src/presenter/navigation/modular_page.dart
+++ b/flutter_modular/lib/src/presenter/navigation/modular_page.dart
@@ -42,6 +42,10 @@ class ModularPage<T> extends Page<T> {
     if (transitionType == TransitionType.custom &&
         route.customTransition != null) {
       final transition = route.customTransition!;
+      if (transition.routeBuilder != null) {
+        return transition.routeBuilder!((context) => page, this) as Route<T>;
+      }
+
       return PageRouteBuilder<T>(
         pageBuilder: transition.pageBuilder ?? (context, _, __) => page,
         opaque: transition.opaque,

--- a/flutter_modular/test/src/presenter/navigation/modular_page_test.dart
+++ b/flutter_modular/test/src/presenter/navigation/modular_page_test.dart
@@ -173,4 +173,25 @@ void main() {
     expect(page.createRoute(context), isA<Route>());
     expect(page.route.isFullscreenDialog, equals(true));
   });
+
+  test('createRoute custom route builder', () {
+    final args = ModularArguments.empty();
+    final context = BuildContextMock();
+    final route = ParallelRouteMock();
+    final widget = Container();
+    when(() => route.child).thenReturn((_) => widget);
+    when(() => route.uri).thenReturn(Uri.parse('/'));
+    when(() => route.transition).thenReturn(TransitionType.custom);
+    when(() => route.customTransition).thenReturn(CustomTransition(
+      transitionBuilder: (_, __, ___, child) => child,
+      routeBuilder: (builder, settings) => CupertinoSheetRoute(
+        builder: builder,
+        settings: settings,
+      ),
+    ));
+
+    final page = ModularPage(args: args, flags: ModularFlags(), route: route);
+    final pageRoute = page.createRoute(context);
+    expect(pageRoute, isA<CupertinoSheetRoute>());
+  });
 }


### PR DESCRIPTION
# Description

Added the `routeBuilder` parameter to `CustomTransition` to allow creating routes with `CupertinoSheetRoute`.
The change is simple and has no side effects.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
