### PR TITLE
chore: remove shelf_modular from workspace and CI

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -57,29 +57,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         
-  shelf_modular:
-    name: shelf modular
-    runs-on: ubuntu-latest
-    
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: '12.x'
-    - uses: subosito/flutter-action@v1
-      with:
-        flutter-version: '3.10.6'
-    
-    - name: get packages
-      run: flutter pub get
-      working-directory: shelf_modular
-    
-    - name: Flutter Test
-      run: flutter test --coverage --coverage-path ../coverage/lcov.info
-      working-directory: shelf_modular
-      
-    - name: Codecov GitHub Action
-      uses: codecov/codecov-action@v2.0.3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,5 @@ environment:
 workspace:
   - modular_core
   - flutter_modular
-  - shelf_modular
   # examples
   - flutter_modular/example
-  - shelf_modular/example


### PR DESCRIPTION
## Summary

- Removes `shelf_modular` and `shelf_modular/example` from the Dart workspace (`pubspec.yaml`)
- Removes the `shelf_modular` CI job from `.github/workflows/dart.yml`
- Repo now contains only `modular_core` and `flutter_modular`

## Test plan

- [ ] Verify CI passes for `flutter_modular` and `modular_core` jobs
- [ ] Confirm `melos bootstrap` succeeds with only the two remaining packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)