### PR TITLE
feat: Expose a route stream on RouterOutlets

### DIFF
--- a/lib/src/navigation/outlet.dart
+++ b/lib/src/navigation/outlet.dart
@@ -114,6 +114,10 @@ class RouterOutletState extends State<RouterOutlet> {
   final List<_OutletEntry> _stack = [];
   int _seq = 0;
 
+  /// Expose a event stream of the routes change
+  final _routeController = StreamController<Uri>.broadcast();
+  Stream<Uri> get onRouteChanged => _routeController.stream;
+
   /// Whether this outlet has a sub-route above its seed to pop.
   bool get canPop => _stack.length > 1;
 
@@ -146,6 +150,12 @@ class RouterOutletState extends State<RouterOutlet> {
     }
   }
 
+  @override
+  void dispose() {
+    _routeController.close();
+    super.dispose();
+  }
+
   _OutletEntry _entry(Uri uri, Object? arguments) => _OutletEntry(
     uri,
     ValueKey('outlet-${identityHashCode(this)}-${_seq++}'),
@@ -158,7 +168,7 @@ class RouterOutletState extends State<RouterOutlet> {
   Future<T?> push<T extends Object?>(String path, {Object? arguments}) {
     final entry = _entry(Uri.parse(path), arguments);
     setState(() => _stack.add(entry));
-    _reportLocation();
+    _reportLocation(path);
     return entry.completer.future.then((value) => value as T?);
   }
 
@@ -186,7 +196,7 @@ class RouterOutletState extends State<RouterOutlet> {
         ..clear()
         ..add(_entry(Uri.parse(path), arguments));
     });
-    _reportLocation();
+    _reportLocation(path);
   }
 
   /// Replaces this outlet's TOP sub-route with [path].
@@ -197,7 +207,7 @@ class RouterOutletState extends State<RouterOutlet> {
     }
     final entry = _entry(Uri.parse(path), arguments);
     setState(() => _stack.add(entry));
-    _reportLocation();
+    _reportLocation(path);
     return entry.completer.future.then((value) => value as T?);
   }
 
@@ -228,7 +238,7 @@ class RouterOutletState extends State<RouterOutlet> {
     }
     final entry = _entry(Uri.parse(path), arguments);
     setState(() => _stack.add(entry));
-    _reportLocation();
+    _reportLocation(path);
     return entry.completer.future.then((value) => value as T?);
   }
 
@@ -252,15 +262,23 @@ class RouterOutletState extends State<RouterOutlet> {
       if (!removed.completer.isCompleted) removed.completer.complete(null);
     }
     setState(() {});
-    _reportLocation();
+    _reportLocation(path);
     return entry.completer.future.then((value) => value as T?);
   }
 
   /// Reports this outlet's current base sub-route to the root delegate so the
   /// URL reflects the outlet (a tab switch shows up). A push/pop leaves the
   /// base unchanged, so it reports the same value and stays out of the URL.
-  void _reportLocation() {
+  void _reportLocation([String? path]) {
     if (_stack.isEmpty) return;
+
+    /// Convert the String path to a Uri and notfiy the route stream
+    if (path != null) {
+      _routeController.add(Uri.parse(path));
+    } else {
+      _routeController.add(_stack.last.uri);
+    }
+
     final delegate = Router.maybeOf(context)?.routerDelegate;
     if (delegate is ModularRouterDelegate) {
       delegate.reportNestedLocation(_stack.first.uri);


### PR DESCRIPTION
# Description

This adds a Uri Stream that can be listened to as the current `context.routeState()` doesn't update everywhere and can be caught within apps that have Scaffold's within Scaffolds

```
import 'dart:async';

import 'package:flutter/material.dart';
import 'package:flutter_modular/flutter_modular.dart';
import 'package:modular_7/app_module.dart';

class AppRootWidget extends StatefulWidget {
  const AppRootWidget({super.key});

  @override
  State<AppRootWidget> createState() => _AppRootWidgetState();
}

class _AppRootWidgetState extends State<AppRootWidget> {
  final GlobalKey<RouterOutletState> _outlet = GlobalKey<RouterOutletState>();
  late final StreamSubscription? _outletRouteChangeSubscription;
  int _selectedTabIndex = 0;

  @override
  void initState() {
    super.initState();

    WidgetsBinding.instance.addPostFrameCallback((_) {
      final path = context.routeState(listen: false).uri.path;
      _tabSelected(path);

      _outletRouteChangeSubscription = _outlet.currentState?.onRouteChanged
          .listen((Uri uri) => _onRouteChange(uri));
    });
  }

  @override
  void dispose() {
    super.dispose();
    _outletRouteChangeSubscription?.cancel();
  }

  void _onRouteChange(Uri uri) {
    _tabSelected("$uri");
  }

  @override
  void didChangeDependencies() {
    super.didChangeDependencies();
  }

  void _tabSelected(String path) {
    String topLevel =
        path
            .split("/")
            .where((String stringVal) => stringVal.isNotEmpty)
            .firstOrNull ??
        "home";

    switch (topLevel) {
      case "about":
        setState(() {
          _selectedTabIndex = 1;
        });
      case "contact":
        setState(() {
          _selectedTabIndex = 2;
        });
      default:
        setState(() {
          _selectedTabIndex = 0;
        });
    }
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text("This is the App Root"),
      ),
      body: Column(
        children: [
          Expanded(
            child: RouterOutlet(
              key: _outlet,
            ),
          ),
        ],
      ),
      bottomNavigationBar: BottomNavigationBar(
        currentIndex: _selectedTabIndex,
        onTap: (int index) {
          switch (index) {
            case 1:
              _outlet.currentState?.navigate(ROUTES.aboutScreen);
              break;
            case 2:
              _outlet.currentState?.navigate(ROUTES.contactScreen);
              break;

            default:
              _outlet.currentState?.navigate(ROUTES.homeScreen);
          }
        },
        items: [
          BottomNavigationBarItem(icon: Icon(Icons.eighteen_mp), label: "Home"),
          BottomNavigationBarItem(
            icon: Icon(Icons.eighteen_mp),
            label: "About",
          ),
          BottomNavigationBarItem(
            icon: Icon(Icons.eighteen_mp),
            label: "Contact",
          ),
        ],
      ),
    );
  }
}

```

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [ ] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `doc` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `example`.

## Breaking Change

<!-- Does your PR require Modular users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/Flutterando/modular/issues
[Contributor Guide]: https://github.com/Flutterando/modular/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
